### PR TITLE
Update bitboard.hpp to fix the bug that made == the same as !=

### DIFF
--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -61,7 +61,7 @@ struct Move {
 		return data == m.data;
 	};
 	constexpr bool operator!=(const Move &m) const {
-		return data == m.data;
+		return data != m.data;
 	};
 	std::string to_string() const;
 };


### PR DESCRIPTION
There appears to be an error in the file `bitboard.hpp` that makes the operator `!=` on the `Move` struct the same as `==`. Therefore, I have changed the file so that `!=` represents inequality.