### PR TITLE
bench: 273173 add history

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -184,7 +184,7 @@ pzstd::vector<std::pair<Move, Value>> order_moves(Board &board, pzstd::vector<Mo
 			score = PieceValue[move.promotion() + KNIGHT] - PawnValue;
 		} else {
 			// Non-capture, non-promotion, so check history
-			// score = history[board.side][move.src()][move.dst()];
+			score = history[board.side][move.src()][move.dst()];
 		}
 		if (move == killer[0][depth]) {
 			score += 1000; // Killer move bonus


### PR DESCRIPTION
```
Elo   | 147.51 +- 30.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.28 (-2.94, 2.94) [0.00, 10.00]
Games | N: 262 W: 128 L: 23 D: 111
Penta | [0, 7, 40, 56, 28]
```
https://sscg13.pythonanywhere.com/test/130/