### PR TITLE
Fix 50-move rule handling - also fixes a part of illegal PV

### DIFF
--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -166,6 +166,14 @@ void Board::load_fen(std::string fen) {
 		inputIdx += 2;
 	}
 
+	// Get halfmove clock
+	halfmove = 0;
+	while (inputIdx < fen.size() && std::isdigit(fen[inputIdx])) {
+		halfmove *= 10;
+		halfmove += fen[inputIdx] - '0';
+		inputIdx++;
+	}
+
 	// Ignore the rest (who cares anyways)
 
 	// Recompute hash

--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -236,9 +236,6 @@ Value eval(Board &board) {
 		// Likewise, if white has no king, this is mate for black
 		return -VALUE_MATE;
 	}
-	if (board.halfmove >= 100) {
-		return 0; // Draw by 50 moves
-	}
 
 	// Query the NNUE network
 	for (uint16_t i = 0; i < 64; i++) {

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -252,8 +252,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	}
 
 	// Threefold or 50 move rule
-	if (board.threefold() || board.halfmove >= 100)
+	if (board.threefold() || board.halfmove >= 100) {
 		return 0;
+	}
 
 	bool in_check = false;
 	if (board.side == WHITE) {
@@ -546,6 +547,8 @@ std::pair<Move, Value> search(Board &board, int64_t time, bool quiet) {
 		eval = result.second;
 		best_move = result.first;
 
+		seldepth = std::max(seldepth, d);
+
 #ifndef NOUCI
 		if (!quiet) {
 			if (abs(eval) >= VALUE_MATE_MAX_PLY) {
@@ -617,6 +620,8 @@ std::pair<Move, Value> search_depth(Board &board, int depth, bool quiet) {
 			break;
 		eval = result.second;
 		best_move = result.first;
+
+		seldepth = std::max(seldepth, d);
 
 #ifndef NOUCI
 		if (!quiet) {


### PR DESCRIPTION
```
Elo   | -0.70 +- 4.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-10.00, 0.00]
Games | N: 9414 W: 1926 L: 1945 D: 5543
Penta | [165, 1139, 2125, 1106, 172]
```
https://sscg13.pythonanywhere.com/test/160/