### PR TITLE
Add reverse futility pruning

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -349,7 +349,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 				score = -__recurse(board, depth - 1, -beta, -alpha, -side, 0, ply+1);
 			}
 		} else {
-			score = -__recurse(board, depth - 1, -beta, -alpha, -side, 1, ply+1);
+			score = -__recurse(board, depth - 1, -beta, -alpha, -side, pv, ply+1);
 		}
 
 		if (abs(score) >= VALUE_MATE_MAX_PLY)

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -309,19 +309,19 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	}
 
 	// Reverse futility pruning
-	// if (!in_check && entry_exists && !pv) {
-	// 	/**
-	// 	 * The idea is that if we are winning by such a large margin that we can afford to lose
-	// 	 * RFP_THRESHOLD * depth eval units per ply, we can return the current eval.
-	// 	 * 
-	// 	 * We need to make sure that we aren't in check (since we might get mated) and that the
-	// 	 * TT entry exists (so that the current position is actually good).
-	// 	 */
-	// 	int cur_eval = eval(board) * side; // TODO: Use the TT entry instead of the eval function?
-	// 	int margin = RFP_THRESHOLD * depth;
-	// 	if (cur_eval >= beta + margin)
-	// 		return cur_eval;
-	// }
+	if (!in_check && !pv && depth <= 3) {
+		/**
+		 * The idea is that if we are winning by such a large margin that we can afford to lose
+		 * RFP_THRESHOLD * depth eval units per ply, we can return the current eval.
+		 * 
+		 * We need to make sure that we aren't in check (since we might get mated) and that the
+		 * TT entry exists (so that the current position is actually good).
+		 */
+		int cur_eval = eval(board) * side; // TODO: Use the TT entry instead of the eval function?
+		int margin = RFP_THRESHOLD * depth;
+		if (cur_eval >= beta + margin)
+			return cur_eval;
+	}
 
 	Move best_move = NullMove;
 

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -10,7 +10,7 @@
 // RFP stops searching if our position is so good that
 // we can afford to lose RFP_THRESHOLD eval units per ply
 // and still be in a better position
-#define RFP_THRESHOLD (150 * CP_SCALE_FACTOR)
+#define RFP_THRESHOLD (200 * CP_SCALE_FACTOR)
 
 // Aspiration window size(s)
 // The aspiration window is the range of values we search

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -9,8 +9,9 @@
 // Eval per ply threshold for RFP
 // RFP stops searching if our position is so good that
 // we can afford to lose RFP_THRESHOLD eval units per ply
-// and still be in a better position
-#define RFP_THRESHOLD (200 * CP_SCALE_FACTOR)
+// and still be in a better position. The lower the value,
+// the more aggressive RFP is.
+#define RFP_THRESHOLD (150 * CP_SCALE_FACTOR)
 
 // Aspiration window size(s)
 // The aspiration window is the range of values we search


### PR DESCRIPTION
```
Elo   | 17.56 +- 7.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2772 W: 620 L: 480 D: 1672
Penta | [32, 290, 643, 348, 73]
```
https://sscg13.pythonanywhere.com/test/185/

Some tweaking should be done on RFP_THRESHOLD before merging