### PR TITLE
bench: 63404 disable nmp when pieces < 8

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -291,7 +291,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	}
 
 	// Null-move pruning
-	if (!in_check) {
+	if (!in_check && _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) >= 8) {
 		/**
 		 * This works off the *null-move observation*.
 		 * 


### PR DESCRIPTION
```
Elo   | 8.28 +- 5.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6546 W: 1396 L: 1240 D: 3910
Penta | [111, 697, 1519, 817, 129]
```
https://sscg13.pythonanywhere.com/test/192/