### PR TITLE
add gravity for history

### DIFF
--- a/engine/includes.hpp
+++ b/engine/includes.hpp
@@ -37,6 +37,8 @@ constexpr Value RookValue = 525;
 constexpr Value QueenValue = 1000;
 constexpr Value VALUE_MAX = QueenValue * 9 + (KnightValue + BishopValue + RookValue) * 2;
 
+constexpr Value MAX_HISTORY = 16384;
+
 #ifdef HCE
 #define CP_SCALE_FACTOR 4
 #else


### PR DESCRIPTION
Change history to use the gravity formula as well as giving maluses

```
Elo   | 16.24 +- 7.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3126 W: 752 L: 606 D: 1768
Penta | [48, 344, 654, 448, 69]
```
https://sscg13.pythonanywhere.com/test/299/