### PR TITLE
uncap rfp depth limit

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -289,7 +289,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	if (!in_check) cur_eval = eval(board) * side;
 
 	// Reverse futility pruning
-	if (!in_check && !pv && depth <= 3) {
+	if (!in_check && !pv) {
 		/**
 		 * The idea is that if we are winning by such a large margin that we can afford to lose
 		 * RFP_THRESHOLD * depth eval units per ply, we can return the current eval.


### PR DESCRIPTION
Elo   | 5.70 +- 4.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10910 W: 2330 L: 2151 D: 6429
Penta | [211, 1215, 2450, 1342, 237]
https://sscg13.pythonanywhere.com/test/312/