### PR TITLE
Add correction history for material

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ EXE ?= pzchessbot
 EVALFILE ?= nnue.bin
 
 CXX := g++
-CXXFLAGS := -std=c++17 -static -DNNUE_PATH=\"$(EVALFILE)\" -mavx2 -mbmi2 -mbmi -mavx -m64 -mpopcnt -mlzcnt
-RELEASEFLAGS = -O3
+CXXFLAGS := -std=c++17 -DNNUE_PATH=\"$(EVALFILE)\" -mavx2 -mbmi2 -mbmi -mavx -m64 -mpopcnt -mlzcnt
+RELEASEFLAGS = -O3 -static
 DEBUGFLAGS = -g -fsanitize=address,undefined
 
 SRCS := $(wildcard engine/*.cpp engine/nnue/*.cpp)

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -790,6 +790,15 @@ bool Board::threefold() {
 	return false;
 }
 
-uint64_t Board::pawn_struct_hash() {
+uint64_t Board::pawn_struct_hash() const {
 	return pawn_hash;
+}
+
+uint64_t Board::material_hash() const {
+	int npawns = _mm_popcnt_u64(piece_boards[PAWN]);
+	int nknights = _mm_popcnt_u64(piece_boards[KNIGHT]);
+	int nbishops = _mm_popcnt_u64(piece_boards[BISHOP]);
+	int nrooks = _mm_popcnt_u64(piece_boards[ROOK]);
+	int nqueens = _mm_popcnt_u64(piece_boards[QUEEN]);
+	return npawns * 23 + nknights * 29 * 23 + nbishops * 31 * 29 * 23 + nrooks * 37 * 31 * 29 * 23 + nqueens * 41 * 37 * 31 * 29 * 23;
 }

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -756,3 +756,16 @@ bool Board::threefold() {
 	}
 	return false;
 }
+
+uint64_t Board::pawn_struct_hash() {
+	uint64_t hash = 0;
+	Bitboard pawns = piece_boards[PAWN];
+	
+	while (pawns) {
+		int sq = __builtin_ctzll(pawns);
+		hash ^= zobrist_square[sq][mailbox[sq]];
+		pawns &= pawns - 1;
+	}
+	
+	return hash;
+}

--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -67,6 +67,7 @@ struct Board {
 	uint8_t castling = 0xf; // 1111
 	Square ep_square = SQ_NONE;
 	uint64_t zobrist = 0;
+	uint64_t pawn_hash = 0;
 	TTable ttable;
 	pzstd::largevector<uint64_t> hash_hist;
 

--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -121,5 +121,6 @@ struct Board {
 
 	bool threefold();
 
-	uint64_t pawn_struct_hash();
+	uint64_t pawn_struct_hash() const;
+	uint64_t material_hash() const;
 };

--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -119,4 +119,6 @@ struct Board {
 	void recompute_hash();
 
 	bool threefold();
+
+	uint64_t pawn_struct_hash();
 };

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -136,7 +136,7 @@ void apply_correction(bool side, uint64_t pshash, uint64_t mathash, Value &eval)
 		return; // Don't apply correction if we are already at a mate score
 	const Value pscorr = corrhist_ps[side][pshash % CORRHIST_SZ];
 	const Value matcorr = corrhist_mat[side][mathash % CORRHIST_SZ];
-	const Value corr = pscorr + matcorr;
+	const Value corr = (pscorr + matcorr) / 2;
 	eval = std::clamp(eval + corr / CORRHIST_GRAIN, -VALUE_MATE_MAX_PLY + 1, VALUE_MATE_MAX_PLY - 1);
 }
 

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -33,6 +33,11 @@
 #define FUTILITY_THRESHOLD (312 * CP_SCALE_FACTOR)
 #define FUTILITY_THRESHOLD2 (678 * CP_SCALE_FACTOR)
 
+// Correction history table size
+#define CORRHIST_SZ 32768
+#define CORRHIST_GRAIN 256
+#define CORRHIST_WEIGHT 256
+
 extern uint64_t nodes;
 
 std::pair<Move, Value> search(Board &board, int64_t time = 1e9, bool quiet = false);


### PR DESCRIPTION
```
Elo   | 5.20 +- 3.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11224 W: 2203 L: 2035 D: 6986
Penta | [148, 1221, 2751, 1299, 193]
```
https://sscg13.pythonanywhere.com/test/365/

Tested as mat-corrhist vs corrhist