### PR TITLE
Change NMP to avoid pruning in non-pawn endgames

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -352,7 +352,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	}
 
 	// Null-move pruning
-	if (!in_check && _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) >= 8) {
+	int npieces = _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]);
+	int npawns_and_kings = _mm_popcnt_u64(board.piece_boards[PAWN] | board.piece_boards[KING]);
+	if (!in_check && npieces != npawns_and_kings) { // Avoid NMP in pawn endgames
 		/**
 		 * This works off the *null-move observation*.
 		 * 


### PR DESCRIPTION
```
Elo   | 10.75 +- 5.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3396 W: 719 L: 614 D: 2063
Penta | [3, 270, 1050, 369, 6]
```
https://sscg13.pythonanywhere.com/test/373/

Tested on endgame book