### PR TITLE
Use TT eval (when available) instead of static eval

### DIFF
--- a/engine/ttable.hpp
+++ b/engine/ttable.hpp
@@ -53,7 +53,7 @@ struct TTable {
 
 	void store(uint64_t key, Value eval, uint8_t depth, TTFlag flag, Move best_move, uint8_t age);
 
-	TTEntry *probe(uint64_t key, Value alpha, Value beta, Value depth);
+	TTEntry *probe(uint64_t key, Value alpha=VALUE_INFINITE, Value beta=-VALUE_INFINITE, Value depth=0);
 
 	constexpr uint64_t size() const { return tsize; }
 	constexpr uint64_t mxsize() const { return TT_SIZE; }


### PR DESCRIPTION
```
Elo   | 13.29 +- 6.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3296 W: 613 L: 487 D: 2196
Penta | [25, 315, 868, 389, 51]
```
https://sscg13.pythonanywhere.com/test/468/

uhhh we dont talk about it
