### PR TITLE
Better ordering

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -261,11 +261,10 @@ pzstd::vector<std::pair<Move, Value>> assign_values(Board &board, pzstd::vector<
 		if (capt || promo) {
 			// 2. Captures + promotions
 			score = CAPTURE_PROMO_BASE;
-			if (capt) {
+			if (capt)
 				score += PieceValue[board.mailbox[move.dst()] & 7] + capthist[board.mailbox[move.src()] & 7][board.mailbox[move.dst()] & 7][move.dst()];
-			} else if (promo) {
+			if (promo)
 				score += PieceValue[move.promotion() + KNIGHT] - PawnValue;
-			}
 		} else {
 			// 3. Quiets
 			score = QUIET_BASE + history[board.side][move.src()][move.dst()];

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -252,13 +252,14 @@ pzstd::vector<std::pair<Move, Value>> assign_values(Board &board, pzstd::vector<
 		// 1. TTMove must be first (don't do this outside loop because zobrist collisions can lead to illegal moves)
 		if (tentry && move == tentry->best_move) {
 			scores.push_back({move, TT_MOVE_BASE});
+			continue;
 		}
 
 		bool capt = (board.piece_boards[OPPOCC(board.side)] & square_bits(move.dst()));
 		bool promo = (move.type() == PROMOTION);
 
 		Value score = 0;
-		
+
 		if (capt || promo) {
 			// 2. Captures + promotions
 			score = CAPTURE_PROMO_BASE;
@@ -280,7 +281,7 @@ pzstd::vector<std::pair<Move, Value>> assign_values(Board &board, pzstd::vector<
 				score += 1021; // Counter-move bonus
 			}
 		}
-		
+
 		scores.push_back({move, score});
 	}
 	


### PR DESCRIPTION
```
Elo   | 5.40 +- 5.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 6180 W: 1537 L: 1441 D: 3202
Penta | [78, 736, 1368, 828, 80]
```
https://sscg13.pythonanywhere.com/test/541/

Bench: 128695