### PR TITLE
Use improving flag to lower RFP margin

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -382,7 +382,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 * 
 		 * We need to make sure that we aren't in check (since we might get mated)
 		 */
-		int margin = RFP_THRESHOLD * depth;
+		int margin = (RFP_THRESHOLD - improving * RFP_IMPROVING) * depth;
 		if (cur_eval >= beta + margin)
 			return cur_eval - margin;
 	}

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -12,6 +12,7 @@
 // and still be in a better position. The lower the value,
 // the more aggressive RFP is.
 #define RFP_THRESHOLD (131 * CP_SCALE_FACTOR)
+#define RFP_IMPROVING (30 * CP_SCALE_FACTOR)
 
 // Aspiration window size(s)
 // The aspiration window is the range of values we search


### PR DESCRIPTION
```
Elo   | 18.01 +- 7.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2394 W: 590 L: 466 D: 1338
Penta | [15, 248, 563, 340, 31]
```
https://sscg13.pythonanywhere.com/test/563/

Bench: 63128