### PR TITLE
Add history pruning

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -471,6 +471,18 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			continue;
 		}
 
+		if (!in_check && !capt && !promo && depth <= 5) {
+			/**
+			 * History pruning
+			 * 
+			 * Skip moves with very bad history scores
+			 */
+			Value hist = history[board.side][move.src()][move.dst()];
+			if (hist < -HISTORY_MARGIN * depth) {
+				continue;
+			}
+		}
+
 		if (depth <= 2 && i > 0 && !in_check && !capt && !promo && abs(alpha) < VALUE_MATE_MAX_PLY && abs(beta) < VALUE_MATE_MAX_PLY) {
 			/**
 			 * Futility pruning

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -37,6 +37,10 @@
 // This is the margin for razoring (in centipawns)
 #define RAZOR_MARGIN (241 * CP_SCALE_FACTOR)
 
+// History pruning margin
+// This is the margin for history pruning (in centipawns)
+#define HISTORY_MARGIN (4000 * CP_SCALE_FACTOR)
+
 // Correction history table size
 #define CORRHIST_SZ 32768
 #define CORRHIST_GRAIN 256


### PR DESCRIPTION
```
Elo   | 20.82 +- 8.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2122 W: 556 L: 429 D: 1137
Penta | [18, 207, 494, 314, 28]
```
https://sscg13.pythonanywhere.com/test/562/

Bench: 90623