### PR TITLE
Add QSearch futility pruning

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -210,6 +210,9 @@ Value quiesce(Board &board, Value alpha, Value beta, int side, int depth) {
 			Value see = board.see_capture(move);
 			if (see < 0) {
 				continue; // Don't search moves that lose material
+			} else {
+				// sort of like delta pruning but more safe
+				if (DELTA_THRESHOLD + 4 * see + stand_pat < alpha) continue;
 			}
 		}
 


### PR DESCRIPTION
STC:

```
Elo   | 7.22 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6736 W: 1569 L: 1429 D: 3738
Penta | [45, 792, 1573, 894, 64]
```
https://sscg13.pythonanywhere.com/test/573/

Prelim. LTC:

```
Elo   | 17.24 +- 13.88 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.01 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 706 W: 171 L: 136 D: 399
Penta | [2, 72, 176, 95, 8]
```
https://sscg13.pythonanywhere.com/test/583/

wtf is this scaling?

Bench: 679159