### PR TITLE
Reduce more if tentry is a capture

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -516,6 +516,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			 */
 			Value r = reduction[i][depth];
 			r -= 512 * pv;
+			if (tentry && (board.piece_boards[OCC(board.side)] & square_bits(tentry->best_move.dst())))
+				// reduce more if tentry is a capture
+				r += 800;
 			if (r < 1024) r = 1024; // ensure at least 1 ply reduction
 			score = -__recurse(board, depth - r / 1024, -alpha - 1, -alpha, -side, 0, ply+1);
 			if (score > alpha) {


### PR DESCRIPTION
```
Elo   | 6.44 +- 4.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8366 W: 2020 L: 1865 D: 4481
Penta | [83, 981, 1930, 1076, 113]
```
https://sscg13.pythonanywhere.com/test/622/

Bench: 866499