### PR TITLE
fix killer move handling

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -552,9 +552,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			if (line[ply].excl == NullMove) {
 				board.ttable.store(board.zobrist, best, depth, LOWER_BOUND, best_move, board.halfmove);
 			}
-			if (killer[0][depth] != move) {
-				killer[1][depth] = killer[0][depth];
-				killer[0][depth] = move; // Update killer moves
+			if (killer[0][ply] != move) {
+				killer[1][ply] = killer[0][ply];
+				killer[0][ply] = move; // Update killer moves
 			}
 			if (!capt) { // Not a capture
 				const Value bonus = 1.56 * depth * depth + 0.91 * depth + 0.62;
@@ -660,9 +660,9 @@ std::pair<Move, Value> __search(Board &board, int depth, Value alpha = -VALUE_IN
 
 		if (score >= beta) {
 			board.ttable.store(board.zobrist, best_score, depth, LOWER_BOUND, best_move, board.halfmove);
-			if (killer[0][depth] != move) {
-				killer[1][depth] = killer[0][depth];
-				killer[0][depth] = move;
+			if (killer[0][0] != move) {
+				killer[1][0] = killer[0][0];
+				killer[0][0] = move;
 			}
 			return {best_move, best_score};
 		}


### PR DESCRIPTION
```
Elo   | 18.06 +- 7.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2388 W: 594 L: 470 D: 1324
Penta | [21, 233, 559, 363, 18]
```
https://sscg13.pythonanywhere.com/test/638/

Bench: 491836