### PR TITLE
skip low depth nodes with bad see

### DIFF
--- a/engine/movegen.cpp
+++ b/engine/movegen.cpp
@@ -565,11 +565,7 @@ Value Board::see_capture(Move move) {
 	PieceType victim = PieceType(mailbox[dst] & 7);
 	int gain[32], d = 0;
 
-	if (victim == NO_PIECETYPE) {
-		return 0;
-	}
-
-	gain[d] = PieceValue[victim];
+	gain[d] = victim == NO_PIECETYPE ? 0 : PieceValue[victim]; // Initial gain from capturing the victim
 
 	int side = (mailbox[src] & 8) >> 3; // 0 for white, 1 for black
 

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -498,6 +498,17 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			if (depth == 2 && cur_eval + FUTILITY_THRESHOLD2 < alpha) continue;
 		}
 
+		if (depth <= 3 && !promo && best > -VALUE_INFINITE) {
+			/**
+			 * PVS SEE Pruning
+			 * 
+			 * Skip searching moves with bad SEE scores
+			 */
+			Value see = board.see_capture(move);
+			if (see < -320)
+				continue;
+		}
+
 		board.make_move(move);
 
 		Value score;


### PR DESCRIPTION
```
Elo   | 23.99 +- 9.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 1900 W: 536 L: 405 D: 959
Penta | [22, 178, 432, 283, 35]
```
https://sscg13.pythonanywhere.com/test/677/

Bench: 648426