### PR TITLE
Do not clear corrhist on search

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -723,12 +723,6 @@ std::pair<Move, Value> search(Board &board, int64_t time, bool quiet) {
 		}
 	}
 
-	for (int i = 0; i < 2; i++) {
-		for (int j = 0; j < CORRHIST_SZ; j++) {
-			corrhist_ps[i][j] = 0;
-		}
-	}
-
 	Move best_move = NullMove;
 	Value eval = -VALUE_INFINITE;
 	bool aspiration_enabled = true;


### PR DESCRIPTION
```
Elo   | 5.16 +- 3.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11036 W: 2569 L: 2405 D: 6062
Penta | [92, 1298, 2626, 1358, 144]
```
https://sscg13.pythonanywhere.com/test/692/

Bench: 648426