### PR TITLE
Raise the depth of the entire node when SE is done

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -456,7 +456,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			line[ply].excl = NullMove; // Reset exclusion move
 
 			if (singular_score < singular_beta) {
-				extension++;
+				depth++;
 			} else if (tentry->eval >= beta) {
 				// Negative extensions
 				extension -= 3;


### PR DESCRIPTION
```
Elo   | 3.29 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21248 W: 4799 L: 4598 D: 11851
Penta | [179, 2542, 5017, 2671, 215]
```
https://sscg13.pythonanywhere.com/test/718/

Bench: 575060