### PR TITLE
Remove CP_SCALE_FACTOR

### DIFF
--- a/engine/includes.hpp
+++ b/engine/includes.hpp
@@ -40,11 +40,7 @@ constexpr Value VALUE_MAX = QueenValue * 9 + (KnightValue + BishopValue + RookVa
 
 constexpr Value MAX_HISTORY = 16384;
 
-#ifdef HCE
-#define CP_SCALE_FACTOR 4
-#else
 #define CP_SCALE_FACTOR 1
-#endif
 
 #ifndef NNUE_PATH
 #define NNUE_PATH "nnue.bin"


### PR DESCRIPTION
Idk why it existed in the first place

```
Elo   | 58.60 +- 15.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 826 W: 240 L: 102 D: 484
Penta | [5, 65, 161, 151, 31]
```
https://sscg13.pythonanywhere.com/test/728/

Bench: 617801