### PR TITLE
Taper pawn and king in endgame

### DIFF
--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -84,6 +84,9 @@ Value eval(Board &board) {
 	Value tempo_bonus = 0;
 	Value pawn_structure = 0;
 
+	Value phase = _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]);
+	Value eg_weight = phase <= 16 ? 20 - phase : 0;
+
 	material += PawnValue * _mm_popcnt_u64(board.piece_boards[PAWN] & board.piece_boards[OCC(WHITE)]);
 	material += KnightValue * _mm_popcnt_u64(board.piece_boards[KNIGHT] & board.piece_boards[OCC(WHITE)]);
 	material += BishopValue * _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(WHITE)]);
@@ -102,12 +105,12 @@ Value eval(Board &board) {
 		PieceType pt = (PieceType)(p & 7);
 		int idx = side == 1 ? i : (56 ^ i);
 		switch (pt) {
-			case PAWN: piecesquare += side * pawn_heatmap[idx]; break;
+			case PAWN: piecesquare += side * ((pawn_heatmap[idx] * (24 - eg_weight)) + (pawn_endgame[idx] * eg_weight)) / 24; break;
 			case KNIGHT: piecesquare += side * knight_heatmap[idx]; break;
 			case BISHOP: piecesquare += side * bishop_heatmap[idx]; break;
 			case ROOK: piecesquare += side * rook_heatmap[idx]; break;
 			case QUEEN: piecesquare += side * queen_heatmap[idx]; break;
-			case KING: piecesquare += side * king_heatmap[idx]; break;
+			case KING: piecesquare += side * ((king_heatmap[idx] * (24 - eg_weight)) + (endgame_heatmap[idx] * eg_weight)) / 24; break;
 		}
 	}
 


### PR DESCRIPTION
```
Elo   | 79.42 +- 17.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.25, 2.89) [0.00, 5.00]
Games | N: 672 W: 234 L: 83 D: 355
Penta | [3, 42, 125, 133, 33]
```
https://sscg13.pythonanywhere.com/test/729/

Bench: 684412