### PR TITLE
Switch to also tapering material

### DIFF
--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -9,6 +9,75 @@ Value simple_eval(Board &board) {
 	return score;
 }
 
+Value piece_value_mg[6] = {82, 337, 365, 477, 1025, 0};
+Value piece_value_eg[6] = {94, 281, 297, 512, 936, 0};
+Value taperer[6] = {0, 1, 1, 2, 4, 0};
+
+Value mg_eval(Board &board, int &phase) {
+	Value material = 0;
+	Value piecesquare = 0;
+	Value bishop_pair = 0;
+
+	for (int i = 0; i < 6; i++) {
+		material += piece_value_mg[i] * _mm_popcnt_u64(board.piece_boards[i] & board.piece_boards[OCC(WHITE)]);
+		material -= piece_value_mg[i] * _mm_popcnt_u64(board.piece_boards[i] & board.piece_boards[OCC(BLACK)]);
+	}
+
+	for (int i = 0; i < 64; i++) {
+		Piece p = board.mailbox[i];
+		if (p == NO_PIECE) continue;
+		int side = p >= 8 ? -1 : 1;
+		PieceType pt = (PieceType)(p & 7);
+		int idx = side == 1 ? i : (56 ^ i);
+		phase += taperer[pt];
+		switch (pt) {
+			case PAWN: piecesquare += side * pawn_heatmap[idx]; break;
+			case KNIGHT: piecesquare += side * knight_heatmap[idx]; break;
+			case BISHOP: piecesquare += side * bishop_heatmap[idx]; break;
+			case ROOK: piecesquare += side * rook_heatmap[idx]; break;
+			case QUEEN: piecesquare += side * queen_heatmap[idx]; break;
+			case KING: piecesquare += side * king_heatmap[idx]; break;
+		}
+	}
+
+	bishop_pair += _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(WHITE)]) >= 2 ? 10 : 0;
+	bishop_pair -= _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(BLACK)]) >= 2 ? 10 : 0;
+
+	return material + piecesquare + bishop_pair;
+}
+
+Value eg_eval(Board &board) {
+	Value material = 0;
+	Value piecesquare = 0;
+	Value bishop_pair = 0;
+
+	for (int i = 0; i < 6; i++) {
+		material += piece_value_eg[i] * _mm_popcnt_u64(board.piece_boards[i] & board.piece_boards[OCC(WHITE)]);
+		material -= piece_value_eg[i] * _mm_popcnt_u64(board.piece_boards[i] & board.piece_boards[OCC(BLACK)]);
+	}
+
+	for (int i = 0; i < 64; i++) {
+		Piece p = board.mailbox[i];
+		if (p == NO_PIECE) continue;
+		int side = p >= 8 ? -1 : 1;
+		PieceType pt = (PieceType)(p & 7);
+		int idx = side == 1 ? i : (56 ^ i);
+		switch (pt) {
+			case PAWN: piecesquare += side * pawn_endgame[idx]; break;
+			case KNIGHT: piecesquare += side * knight_endgame[idx]; break;
+			case BISHOP: piecesquare += side * bishop_endgame[idx]; break;
+			case ROOK: piecesquare += side * rook_endgame[idx]; break;
+			case QUEEN: piecesquare += side * queen_endgame[idx]; break;
+			case KING: piecesquare += side * king_endgame[idx]; break;
+		}
+	}
+
+	bishop_pair += _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(WHITE)]) >= 2 ? 10 : 0;
+	bishop_pair -= _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(BLACK)]) >= 2 ? 10 : 0;
+
+	return material + piecesquare + bishop_pair;
+}
+
 Value eval(Board &board) {
 	if (!(board.piece_boards[KING] & board.piece_boards[OCC(BLACK)])) {
 		// If black has no king, this is mate for white
@@ -19,47 +88,15 @@ Value eval(Board &board) {
 		return -VALUE_MATE;
 	}
 
-	Value material = 0;
-	Value piecesquare = 0;
-	Value bishop_pair = 0;
-	Value king_safety = 0;
-	Value tempo_bonus = 0;
-	Value pawn_structure = 0;
+	int phase = 0;
+	
+	Value mg = mg_eval(board, phase);
+	Value eg = eg_eval(board);
 
-	Value phase = _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]);
-	Value eg_weight = phase <= 16 ? 20 - phase : 0;
+	if (phase > 24) phase = 24;
 
-	material += PawnValue * _mm_popcnt_u64(board.piece_boards[PAWN] & board.piece_boards[OCC(WHITE)]);
-	material += KnightValue * _mm_popcnt_u64(board.piece_boards[KNIGHT] & board.piece_boards[OCC(WHITE)]);
-	material += BishopValue * _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(WHITE)]);
-	material += RookValue * _mm_popcnt_u64(board.piece_boards[ROOK] & board.piece_boards[OCC(WHITE)]);
-	material += QueenValue * _mm_popcnt_u64(board.piece_boards[QUEEN] & board.piece_boards[OCC(WHITE)]);
-	material -= PawnValue * _mm_popcnt_u64(board.piece_boards[PAWN] & board.piece_boards[OCC(BLACK)]);
-	material -= KnightValue * _mm_popcnt_u64(board.piece_boards[KNIGHT] & board.piece_boards[OCC(BLACK)]);
-	material -= BishopValue * _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(BLACK)]);
-	material -= RookValue * _mm_popcnt_u64(board.piece_boards[ROOK] & board.piece_boards[OCC(BLACK)]);
-	material -= QueenValue * _mm_popcnt_u64(board.piece_boards[QUEEN] & board.piece_boards[OCC(BLACK)]);
-
-	for (int i = 0; i < 64; i++) {
-		Piece p = board.mailbox[i];
-		if (p == NO_PIECE) continue;
-		int side = p >= 8 ? -1 : 1;
-		PieceType pt = (PieceType)(p & 7);
-		int idx = side == 1 ? i : (56 ^ i);
-		switch (pt) {
-			case PAWN: piecesquare += side * ((pawn_heatmap[idx] * (24 - eg_weight)) + (pawn_endgame[idx] * eg_weight)) / 24; break;
-			case KNIGHT: piecesquare += side * ((knight_heatmap[idx] * (24 - eg_weight)) + (knight_endgame[idx] * eg_weight)) / 24; break;
-			case BISHOP: piecesquare += side * ((bishop_heatmap[idx] * (24 - eg_weight)) + (bishop_endgame[idx] * eg_weight)) / 24; break;
-			case ROOK: piecesquare += side * ((rook_heatmap[idx] * (24 - eg_weight)) + (rook_endgame[idx] * eg_weight)) / 24; break;
-			case QUEEN: piecesquare += side * ((queen_heatmap[idx] * (24 - eg_weight)) + (queen_endgame[idx] * eg_weight)) / 24; break;
-			case KING: piecesquare += side * ((king_heatmap[idx] * (24 - eg_weight)) + (king_endgame[idx] * eg_weight)) / 24; break;
-		}
-	}
-
-	bishop_pair += _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(WHITE)]) >= 2 ? 10 : 0;
-	bishop_pair -= _mm_popcnt_u64(board.piece_boards[BISHOP] & board.piece_boards[OCC(BLACK)]) >= 2 ? 10 : 0;
-
-	return material + piecesquare + bishop_pair;
+	Value fin_eval = (mg * phase + eg * (24 - phase)) / 24;
+	return fin_eval;
 }
 
 std::array<Value, 8> debug_eval(Board &board) {


### PR DESCRIPTION
```
Elo   | 148.39 +- 28.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 484 W: 274 L: 79 D: 131
Penta | [3, 28, 60, 73, 78]
```
https://sscg13.pythonanywhere.com/test/745/

Bench: 787085