### PR TITLE
Do not do eval correction when ttEval is mate

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -362,7 +362,10 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	uint64_t pawn_hash = 0;
 	if (!in_check) {
 		pawn_hash = board.pawn_struct_hash();
-		cur_eval = tentry ? tentry->eval : eval(board) * side;
+		if (tentry && abs(tentry->eval) < VALUE_MATE_MAX_PLY)
+			cur_eval = tentry->eval;
+		else
+			cur_eval = eval(board) * side;
 		raw_eval = cur_eval;
 		apply_correction(board.side, pawn_hash, board.material_hash(), cur_eval);
 	}


### PR DESCRIPTION
```
Elo   | 7.56 +- 5.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 4276 W: 1001 L: 908 D: 2367
Penta | [23, 485, 1046, 544, 40]
```
https://sscg13.pythonanywhere.com/test/847/

Bench: 755363