### PR TITLE
Return average of eval and beta in RFP

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -385,7 +385,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 */
 		int margin = (RFP_THRESHOLD - improving * RFP_IMPROVING) * depth;
 		if (cur_eval >= beta + margin)
-			return cur_eval - margin;
+			return (cur_eval + beta) / 2;
 	}
 
 	// Null-move pruning


### PR DESCRIPTION
Passed STC:
```
Elo   | 10.03 +- 5.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4678 W: 1146 L: 1011 D: 2521
Penta | [39, 534, 1067, 651, 48]
```
https://sscg13.pythonanywhere.com/test/881/

Bench: 893263