### PR TITLE
Use TT eval when available in QS

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -177,7 +177,9 @@ Value quiesce(Board &board, Value alpha, Value beta, int side, int depth, bool p
 	}
 
 	seldepth = std::max(depth, seldepth);
-	Value stand_pat = eval(board) * side;
+	Value stand_pat = 0;
+	if (tentry && abs(tentry->eval) < VALUE_MATE_MAX_PLY) stand_pat = tentry->eval;
+	else stand_pat = eval(board) * side;
 	apply_correction(board.side, board.pawn_struct_hash(), board.material_hash(), stand_pat);
 
 	// If it's a mate, stop here since there's no point in searching further


### PR DESCRIPTION
Reduces number of expensive eval calls

Passed STC:
```
Elo   | 8.85 +- 5.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5260 W: 1238 L: 1104 D: 2918
Penta | [28, 612, 1246, 686, 58]
```
https://sscg13.pythonanywhere.com/test/905/

Bench: 793898