### PR TITLE
Use a dynamic PVS SEE margin

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -543,7 +543,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			 * Skip searching moves with bad SEE scores
 			 */
 			Value see = board.see_capture(move);
-			if (see < -320)
+			if (see < (-100 - 100 * capt) * depth)
 				continue;
 		}
 


### PR DESCRIPTION
```
Elo   | 5.17 +- 3.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10560 W: 2521 L: 2364 D: 5675
Penta | [94, 1212, 2536, 1319, 119]
```
https://sscg13.pythonanywhere.com/test/917/

Bench: 692221