### PR TITLE
Adjust NMP R-value based on depth

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -437,8 +437,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 */
 		board.make_move(NullMove);
 		// Perform a reduced-depth search
-		Value r = NMP_R_VALUE;
-		r += std::min(3, (cur_eval - beta) / 400);
+		Value r = NMP_R_VALUE + depth / 4;
 		Value null_score = -__recurse(board, depth - r, -beta, -beta + 1, -side, 0, !cutnode, ply+1);
 		board.unmake_move();
 		if (null_score >= beta)

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -437,7 +437,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 */
 		board.make_move(NullMove);
 		// Perform a reduced-depth search
-		Value null_score = -__recurse(board, depth - NMP_R_VALUE, -beta, -beta + 1, -side, 0, !cutnode, ply+1);
+		Value r = NMP_R_VALUE;
+		r += std::min(3, (cur_eval - beta) / 400);
+		Value null_score = -__recurse(board, depth - r, -beta, -beta + 1, -side, 0, !cutnode, ply+1);
 		board.unmake_move();
 		if (null_score >= beta)
 			return null_score;


### PR DESCRIPTION
```
Elo   | 10.24 +- 5.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4444 W: 1088 L: 957 D: 2399
Penta | [28, 494, 1070, 579, 51]
```
https://sscg13.pythonanywhere.com/test/934/

Bench: 1175773