### PR TITLE
Allow razoring to depth 8

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -445,7 +445,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	}
 
 	// Razoring
-	if (!pv && !in_check && depth <= 3 && cur_eval + RAZOR_MARGIN * depth < alpha) {
+	if (!pv && !in_check && depth <= 8 && cur_eval + RAZOR_MARGIN * depth < alpha) {
 		/**
 		 * If we are losing by a lot, check w/ qsearch to see if we could possibly improve.
 		 * If not, we can prune the search.


### PR DESCRIPTION
```
Elo   | 2.68 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 32562 W: 7694 L: 7443 D: 17425
Penta | [363, 3799, 7716, 4030, 373]
```
https://sscg13.pythonanywhere.com/test/942/

Bench: 1205222