### PR TITLE
Do shallower NMP when far exceeding beta

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -408,7 +408,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	if (!in_check && ply >= 3 && line[ply-2].eval != VALUE_NONE && cur_eval > line[ply-2].eval) improving = true;
 
 	// Reverse futility pruning
-	if (!in_check && !pv) {
+	if (!in_check && !pv && depth <= 8) {
 		/**
 		 * The idea is that if we are winning by such a large margin that we can afford to lose
 		 * RFP_THRESHOLD * depth eval units per ply, we can return the current eval.
@@ -437,7 +437,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 */
 		board.make_move(NullMove);
 		// Perform a reduced-depth search
-		Value r = NMP_R_VALUE + depth / 4;
+		Value r = NMP_R_VALUE + depth / 4 + std::min(3, (cur_eval - beta) / 400);
 		Value null_score = -__recurse(board, depth - r, -beta, -beta + 1, -side, 0, !cutnode, ply+1);
 		board.unmake_move();
 		if (null_score >= beta)


### PR DESCRIPTION
```
Elo   | 5.45 +- 3.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10070 W: 2366 L: 2208 D: 5496
Penta | [82, 1186, 2355, 1316, 96]
```
https://sscg13.pythonanywhere.com/test/947/

Bench: 939386