### PR TITLE
Only do LMR at depth over 2

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -569,7 +569,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 * the search.
 		 */
 		Value score;
-		if (i > 1) {
+		if (depth >= 2 && i > 1) {
 			Value r = reduction[i][depth];
 
 			r -= 512 * pv;


### PR DESCRIPTION
```
Elo   | 7.10 +- 4.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6896 W: 1702 L: 1561 D: 3633
Penta | [57, 772, 1658, 895, 66]
```
https://sscg13.pythonanywhere.com/test/952/

Bench: 697304