### PR TITLE
Don't do LMR on early moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ engine/*.bin
 pzchessbot-linux-avx2-x86_64
 *.bin
 test/test
+*.pgn

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -569,7 +569,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 * the search.
 		 */
 		Value score;
-		if (depth >= 2 && i > 1) {
+		if (depth >= 2 && i > 3) {
 			Value r = reduction[i][depth];
 
 			r -= 512 * pv;


### PR DESCRIPTION
```
Elo   | 5.00 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 5.00]
Games | N: 10908 W: 2597 L: 2440 D: 5871
Penta | [99, 1236, 2638, 1371, 110]
```
https://sscg13.pythonanywhere.com/test/969/

Bench: 933128