### PR TITLE
Only store upper 32 bits of hash

### DIFF
--- a/engine/ttable.cpp
+++ b/engine/ttable.cpp
@@ -2,6 +2,8 @@
 
 void TTable::store(uint64_t key, Value eval, uint8_t depth, TTFlag flag, Move best_move, uint8_t age) {
 	TTBucket *bucket = TT + (key % TT_SIZE);
+
+	key >>= 32; // Use upper 32 bits for the key (since we already verified bottom n bits)
 	
 	TTEntry *depth_entry = &bucket->entries[0];
 	TTEntry *always_entry = &bucket->entries[1];
@@ -47,6 +49,7 @@ void TTable::store(uint64_t key, Value eval, uint8_t depth, TTFlag flag, Move be
 
 TTable::TTEntry *TTable::probe(uint64_t key, Value depth) {
 	TTBucket *bucket = TT + (key % TT_SIZE);
+	key >>= 32;
 	for (int i = 0; i < 2; i++) {
 		TTEntry *entry = &bucket->entries[i];
 		if (entry->key != key || entry->depth < depth)

--- a/engine/ttable.hpp
+++ b/engine/ttable.hpp
@@ -14,7 +14,7 @@ enum TTFlag {
 
 struct TTable {
 	struct TTEntry {
-		uint64_t key;
+		uint32_t key;
 		Move best_move;
 		Value eval;
 		uint8_t depth;
@@ -23,7 +23,6 @@ struct TTable {
 
 		TTEntry() : key(0), best_move(NullMove), eval(0), depth(0), flags(INVALID), age(0) {}
 		const bool valid() const { return flags != INVALID; }
-		const bool operator==(const uint64_t k) const { return key == k; }
 	};
 
 	struct TTBucket {


### PR DESCRIPTION
```
Elo   | 5.74 +- 3.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 9264 W: 2225 L: 2072 D: 4967
Penta | [68, 1087, 2192, 1194, 91]
```
https://sscg13.pythonanywhere.com/test/1007/

Has the effect of giving us more hashtable

Bench: 626681