### PR TITLE
Simplify out reset logic

### DIFF
--- a/engine/boardstate.hpp
+++ b/engine/boardstate.hpp
@@ -7,7 +7,6 @@
 struct BoardState {
 	Accumulator w_acc, b_acc;
 	Piece mailbox[64] = {};
-	int wbucket = -1, bbucket = -1;
 };
 
 extern BoardState bs[NINPUTS * 2][NINPUTS * 2];

--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -60,12 +60,13 @@ float multi(int x) {
 __attribute__((constructor)) void init_network() {
 #ifndef HCE
 	nnue_network.load();
-	for (int i = 0; i < HL_SIZE; i++) {
-		for (int j = 0; j < NINPUTS * 2; j++) {
-			for (int k = 0; k < NINPUTS * 2; k++) {
+	for (int j = 0; j < NINPUTS * 2; j++) {
+		for (int k = 0; k < NINPUTS * 2; k++) {
+			for (int i = 0; i < HL_SIZE; i++) {
 				bs[j][k].w_acc.val[i] = nnue_network.accumulator_biases[i];
 				bs[j][k].b_acc.val[i] = nnue_network.accumulator_biases[i];
 			}
+			for (int i = 0; i < 64; i++) bs[j][k].mailbox[i] = NO_PIECE;
 		}
 	}
 #endif
@@ -256,16 +257,6 @@ Value eval(Board &board) {
 	int winbucket = IBUCKET_LAYOUT[wkingsq];
 	int binbucket = IBUCKET_LAYOUT[bkingsq ^ 56];
 
-	if (winbucket != bs[winbucket][binbucket].wbucket || binbucket != bs[winbucket][binbucket].bbucket) {
-		for (int i = 0; i < HL_SIZE; i++) {
-			bs[winbucket][binbucket].w_acc.val[i] = nnue_network.accumulator_biases[i];
-			bs[winbucket][binbucket].b_acc.val[i] = nnue_network.accumulator_biases[i];
-		}
-		for (int i = 0; i < 64; i++) bs[winbucket][binbucket].mailbox[i] = NO_PIECE;
-		bs[winbucket][binbucket].wbucket = winbucket;
-		bs[winbucket][binbucket].bbucket = binbucket;
-	}
-
 	for (uint16_t i = 0; i < 64; i++) {
 		Piece piece = board.mailbox[i];
 		Piece prevpiece = bs[winbucket][binbucket].mailbox[i];
@@ -321,16 +312,6 @@ std::array<Value, 8> debug_eval(Board &board) {
 	Square bkingsq = (Square)_tzcnt_u64(board.piece_boards[KING] & board.piece_boards[OCC(BLACK)]);
 	int winbucket = IBUCKET_LAYOUT[wkingsq];
 	int binbucket = IBUCKET_LAYOUT[bkingsq ^ 56];
-
-	if (winbucket != bs[winbucket][binbucket].wbucket || binbucket != bs[winbucket][binbucket].bbucket) {
-		for (int i = 0; i < HL_SIZE; i++) {
-			bs[winbucket][binbucket].w_acc.val[i] = nnue_network.accumulator_biases[i];
-			bs[winbucket][binbucket].b_acc.val[i] = nnue_network.accumulator_biases[i];
-		}
-		for (int i = 0; i < 64; i++) bs[winbucket][binbucket].mailbox[i] = NO_PIECE;
-		bs[winbucket][binbucket].wbucket = winbucket;
-		bs[winbucket][binbucket].bbucket = binbucket;
-	}
 
 	// Query the NNUE network
 	for (uint16_t i = 0; i < 64; i++) {


### PR DESCRIPTION
```
Elo   | 0.99 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 16486 W: 3799 L: 3752 D: 8935
Penta | [129, 2009, 3938, 2020, 147]
```
https://sscg13.pythonanywhere.com/test/1012/

Bench: 626681

Very slight speedup