### PR TITLE
Fail firm when failing high

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -612,6 +612,10 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		}
 
 		if (score >= beta) {
+			if (abs(score) < VALUE_MATE_MAX_PLY && abs(alpha) < VALUE_MATE_MAX_PLY) {
+				// note that best and score are functionally equivalent here; best is just what's returned + stored to TT
+				best = (score * depth + beta) / (depth + 1); // wtf?????
+			}
 			if (line[ply].excl == NullMove) {
 				board.ttable.store(board.zobrist, best, depth, LOWER_BOUND, best_move, board.halfmove);
 			}


### PR DESCRIPTION
```
Elo   | 16.63 +- 7.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2614 W: 664 L: 539 D: 1411
Penta | [15, 282, 596, 391, 23]
```
https://sscg13.pythonanywhere.com/test/1013/

Bench: 662241