### PR TITLE
Disallow NMP at low depth

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -429,7 +429,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	// Null-move pruning
 	int npieces = _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]);
 	int npawns_and_kings = _mm_popcnt_u64(board.piece_boards[PAWN] | board.piece_boards[KING]);
-	if (!in_check && npieces != npawns_and_kings && cur_eval >= beta) { // Avoid NMP in pawn endgames
+	if (!in_check && npieces != npawns_and_kings && cur_eval >= beta && depth >= 2) { // Avoid NMP in pawn endgames
 		/**
 		 * This works off the *null-move observation*.
 		 * 


### PR DESCRIPTION
```
Elo   | 5.77 +- 4.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8978 W: 2087 L: 1938 D: 4953
Penta | [74, 1025, 2153, 1152, 85]
```
https://sscg13.pythonanywhere.com/test/1026/

Bench: 744211