### PR TITLE
Reduce less on killer moves

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -579,6 +579,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 
 			r -= 512 * pv;
 			r += 800 * (!pv && cutnode);
+			if (move == killer[0][ply] || move == killer[1][ply]) r -= 512;
 
 			Value searched_depth = depth - r / 1024;
 


### PR DESCRIPTION
```
Elo   | 16.22 +- 7.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2680 W: 685 L: 560 D: 1435
Penta | [14, 279, 645, 372, 30]
```
https://sscg13.pythonanywhere.com/test/1052/

Bench: 878463