### PR TITLE
Do more reduction in LMR

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -577,9 +577,9 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		if (depth >= 2 && i > 3) {
 			Value r = reduction[i][depth];
 
-			r -= 512 * pv;
-			r += 800 * (!pv && cutnode);
-			if (move == killer[0][ply] || move == killer[1][ply]) r -= 512;
+			r -= 1024 * pv;
+			r += 1024 * (!pv && cutnode);
+			if (move == killer[0][ply] || move == killer[1][ply]) r -= 1024;
 
 			Value searched_depth = depth - r / 1024;
 


### PR DESCRIPTION
Passed STC
```
Elo   | 7.46 +- 4.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6850 W: 1665 L: 1518 D: 3667
Penta | [51, 797, 1600, 908, 69]
```
https://sscg13.pythonanywhere.com/test/1063/

Passed LTC
```
Elo   | 8.78 +- 5.04 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4790 W: 1068 L: 947 D: 2775
Penta | [8, 522, 1230, 611, 24]
```
https://sscg13.pythonanywhere.com/test/1064/

Bench: 788726