### PR TITLE
Do not allow entering QS when TT move is available

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -591,6 +591,8 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 			score = -__recurse(board, newdepth, -alpha - 1, -alpha, -side, 0, !cutnode, ply+1);
 		}
 		if (pv && (i == 0 || score > alpha)) {
+			if (tentry && move == tentry->best_move && tentry->depth > 1)
+				newdepth = std::max((int)newdepth, 1); // Make sure we don't enter QS if we have an available TT move
 			score = -__recurse(board, newdepth, -beta, -alpha, -side, 1, false, ply+1);
 		}
 


### PR DESCRIPTION
```
Elo   | 4.89 +- 3.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11148 W: 2588 L: 2431 D: 6129
Penta | [77, 1314, 2646, 1449, 88]
```
https://sscg13.pythonanywhere.com/test/1062/

Bench: 749876