### PR TITLE
Do less LMR on rootnode

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -714,7 +714,7 @@ std::pair<Move, Value> __search(Board &board, int depth, Value alpha = -VALUE_IN
 		Value score;
 		Value newdepth = depth - 1;
 
-		if (i > 1) {
+		if (i > 3) {
 			Value r = reduction[i][depth];
 
 			Value searched_depth = depth - r / 1024;


### PR DESCRIPTION
```
Elo   | 2.39 +- 1.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 38602 W: 9022 L: 8756 D: 20824
Penta | [295, 4584, 9329, 4746, 347]
```
https://sscg13.pythonanywhere.com/test/1054/

Bench: 923723