### PR TITLE
Do more NMP when improving

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -444,7 +444,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 */
 		board.make_move(NullMove);
 		// Perform a reduced-depth search
-		Value r = NMP_R_VALUE + depth / 4 + std::min(3, (cur_eval - beta) / 400);
+		Value r = NMP_R_VALUE + depth / 4 + std::min(3, (cur_eval - beta) / 400) + improving;
 		Value null_score = -__recurse(board, depth - r, -beta, -beta + 1, -side, 0, !cutnode, ply+1);
 		board.unmake_move();
 		if (null_score >= beta)


### PR DESCRIPTION
```
Elo   | 4.80 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11502 W: 2700 L: 2541 D: 6261
Penta | [95, 1306, 2776, 1493, 81]
```
https://sscg13.pythonanywhere.com/test/1078/

Bench: 624139