### PR TITLE
Do not allow NMP in singular searches

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -430,7 +430,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	// Null-move pruning
 	int npieces = _mm_popcnt_u64(board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]);
 	int npawns_and_kings = _mm_popcnt_u64(board.piece_boards[PAWN] | board.piece_boards[KING]);
-	if (!in_check && npieces != npawns_and_kings && cur_eval >= beta && depth >= 2) { // Avoid NMP in pawn endgames
+	if (!in_check && npieces != npawns_and_kings && cur_eval >= beta && depth >= 2 && line[ply].excl == NullMove) { // Avoid NMP in pawn endgames
 		/**
 		 * This works off the *null-move observation*.
 		 * 


### PR DESCRIPTION
```
Elo   | 9.93 +- 5.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4552 W: 1108 L: 978 D: 2466
Penta | [24, 518, 1081, 610, 43]
```
https://sscg13.pythonanywhere.com/test/1079/

Bench: 1038523