### PR TITLE
Reduce history magnitudes for each search

### DIFF
--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -210,6 +210,7 @@ __attribute__((weak)) int main(int argc, char *argv[]) {
 		uint64_t start = clock();
 		for (const auto &fen : bench_positions) {
 			board.reset(fen);
+			clear_search_vars();
 			search(board, 1e9, 14, 1e18, 0);
 			tot_nodes += nodes;
 		}

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -908,7 +908,8 @@ std::pair<Move, Value> search(Board &board, int64_t time, int depth, int64_t max
 
 	for (int i = 0; i < 64; i++) {
 		for (int j = 0; j < 64; j++) {
-			history[0][i][j] = history[1][i][j] = 0;
+			history[0][i][j] /= 2;
+			history[1][i][j] /= 2;
 		}
 	}
 


### PR DESCRIPTION
```
Elo   | 7.63 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6190 W: 1489 L: 1353 D: 3348
Penta | [34, 717, 1475, 817, 52]
```
https://sscg13.pythonanywhere.com/test/1092/

Bench: 5653116