### PR TITLE
Only do IIR on PV and Cutnodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -476,7 +476,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 	pzstd::vector<std::pair<Move, Value>> scores = assign_values(board, moves, ply, tentry);
 	int end = scores.size();
 
-	if (depth > 4 && !(tentry && tentry->best_move != NullMove)) {
+	if ((pv || cutnode) && depth > 4 && !(tentry && tentry->best_move != NullMove)) {
 		depth -= 2; // Internal iterative reductions
 	}
 


### PR DESCRIPTION
```
Elo   | 12.24 +- 6.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 3578 W: 918 L: 792 D: 1868
Penta | [23, 378, 874, 478, 36]
```
https://sscg13.pythonanywhere.com/test/1121/

Bench: 5605749