### PR TITLE
Raise SE margin

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -502,7 +502,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		if (line[ply].excl == NullMove && depth >= 8 && tentry && move == tentry->best_move && tentry->depth >= depth - 2 && tentry->flags != UPPER_BOUND) {
 			// Singular extension
 			line[ply].excl = move;
-			Value singular_beta = tentry->eval - 6 * depth;
+			Value singular_beta = tentry->eval - 4 * depth;
 			Value singular_score = __recurse(board, (depth-1) / 2, singular_beta - 1, singular_beta, side, 0, cutnode, ply);
 			line[ply].excl = NullMove; // Reset exclusion move
 


### PR DESCRIPTION
```
Elo   | 7.65 +- 4.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 6132 W: 1443 L: 1308 D: 3381
Penta | [32, 689, 1503, 796, 46]
```
https://sscg13.pythonanywhere.com/test/1120/

Bench: 6051351