### PR TITLE
Do more LMR in nonPV nodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -580,7 +580,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 		 * the search.
 		 */
 		Value score;
-		if (depth >= 2 && i > 3) {
+		if (depth >= 2 && i >= 1 + 2 * pv) {
 			Value r = reduction[i][depth];
 
 			r -= 1024 * pv;


### PR DESCRIPTION
```
Elo   | 18.56 +- 7.82 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2248 W: 585 L: 465 D: 1198
Penta | [10, 223, 551, 317, 23]
```
https://sscg13.pythonanywhere.com/test/1151/

Bench: 6288578