### PR TITLE
Fix illegal move issue (disallow pruning when no best move)

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -518,47 +518,49 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 
 		line[ply].move = move;
 
-		if (best > -VALUE_MATE_MAX_PLY && i >= 5 + 2 * depth * depth) {
-			/**
-			 * Late Move Pruning
-			 * 
-			 * Just skip later moves that probably aren't good
-			 */
-			break;
-		}
-
-		if (!in_check && !capt && !promo && depth <= 5) {
-			/**
-			 * History pruning
-			 * 
-			 * Skip moves with very bad history scores
-			 * Depth condition is necessary to avoid overflow
-			 */
-			Value hist = history[board.side][move.src()][move.dst()];
-			if (hist < -HISTORY_MARGIN * depth)
+		if (best > -VALUE_MATE_MAX_PLY) {
+			if (i >= 5 + 2 * depth * depth) {
+				/**
+				 * Late Move Pruning
+				 * 
+				 * Just skip later moves that probably aren't good
+				 */
 				break;
-		}
+			}
 
-		if (depth <= 2 && i > 0 && !in_check && !capt && !promo && abs(alpha) < VALUE_MATE_MAX_PLY && abs(beta) < VALUE_MATE_MAX_PLY) {
-			/**
-			 * Futility pruning
-			 * 
-			 * If we are at the leaf of the search, we can prune moves that are
-			 * probably not going to be better than alpha.
-			 */
-			if (depth == 1 && cur_eval + FUTILITY_THRESHOLD < alpha) continue;
-			if (depth == 2 && cur_eval + FUTILITY_THRESHOLD2 < alpha) continue;
-		}
+			if (!in_check && !capt && !promo && depth <= 5) {
+				/**
+				 * History pruning
+				 * 
+				 * Skip moves with very bad history scores
+				 * Depth condition is necessary to avoid overflow
+				 */
+				Value hist = history[board.side][move.src()][move.dst()];
+				if (hist < -HISTORY_MARGIN * depth)
+					break;
+			}
 
-		if (depth <= 3 && !promo && best > -VALUE_INFINITE) {
-			/**
-			 * PVS SEE Pruning
-			 * 
-			 * Skip searching moves with bad SEE scores
-			 */
-			Value see = board.see_capture(move);
-			if (see < (-100 - 100 * capt) * depth)
-				continue;
+			if (depth <= 2 && !in_check && !capt && !promo && abs(alpha) < VALUE_MATE_MAX_PLY && abs(beta) < VALUE_MATE_MAX_PLY) {
+				/**
+				 * Futility pruning
+				 * 
+				 * If we are at the leaf of the search, we can prune moves that are
+				 * probably not going to be better than alpha.
+				 */
+				if (depth == 1 && cur_eval + FUTILITY_THRESHOLD < alpha) continue;
+				if (depth == 2 && cur_eval + FUTILITY_THRESHOLD2 < alpha) continue;
+			}
+
+			if (depth <= 3 && !promo && best > -VALUE_INFINITE) {
+				/**
+				 * PVS SEE Pruning
+				 * 
+				 * Skip searching moves with bad SEE scores
+				 */
+				Value see = board.see_capture(move);
+				if (see < (-100 - 100 * capt) * depth)
+					continue;
+			}
 		}
 
 		board.make_move(move);


### PR DESCRIPTION
```
Elo   | 0.75 +- 2.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 17982 W: 4193 L: 4154 D: 9635
Penta | [120, 2163, 4398, 2178, 132]
```
https://sscg13.pythonanywhere.com/test/1158/

Bench: 5906518