### PR TITLE
Add 1-ply conthist for move ordering only

### DIFF
--- a/engine/history.hpp
+++ b/engine/history.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "includes.hpp"
+
+struct ContHistEntry {
+	Value hist[2][6][64]; // [side][piecetype][to]
+
+	ContHistEntry() {
+		memset(hist, 0, sizeof(hist));
+	}
+};

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -2,6 +2,7 @@
 
 #include "bitboard.hpp"
 #include "eval.hpp"
+#include "history.hpp"
 #include "movegen.hpp"
 #include "ttable.hpp"
 #include <algorithm>
@@ -53,7 +54,9 @@ struct SSEntry {
 	Move move;
 	Value eval;
 	Move excl;
-	SSEntry() : move(NullMove), eval(VALUE_NONE), excl(NullMove) {}
+	ContHistEntry *cont_hist;
+
+	SSEntry() : move(NullMove), eval(VALUE_NONE), excl(NullMove), cont_hist(nullptr) {}
 };
 
 std::pair<Move, Value> search(Board &board, int64_t time = 1e9, int depth = MAX_PLY, int64_t nodes = 1e18, int quiet = 0);


### PR DESCRIPTION
```
Elo   | 4.84 +- 3.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 5.00]
Games | N: 11048 W: 2566 L: 2412 D: 6070
Penta | [67, 1261, 2718, 1407, 71]
```
https://sscg13.pythonanywhere.com/test/1168/

Bench: 8535711