### PR TITLE
2-ply conthist

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -113,6 +113,7 @@ uint64_t nodecnt[64][64];
 int get_conthist(Board &board, Move move, int ply) {
 	int score = 0;
 	if (ply >= 1 && line[ply-1].cont_hist) score += line[ply-1].cont_hist->hist[board.side][board.mailbox[move.src()] & 7][move.dst()];
+	if (ply >= 2 && line[ply-2].cont_hist) score += line[ply-2].cont_hist->hist[board.side][board.mailbox[move.src()] & 7][move.dst()];
 	return score;
 }
 
@@ -129,9 +130,10 @@ void update_history(Board &board, Move &move, int ply, Value bonus) {
 	int cbonus = std::clamp(bonus, (Value)(-MAX_HISTORY), MAX_HISTORY);
 	history[board.side][move.src()][move.dst()] += cbonus - history[board.side][move.src()][move.dst()] * abs(bonus) / MAX_HISTORY;
 	int conthist = get_conthist(board, move, ply);
-	if (ply >= 1 && line[ply-1].cont_hist) {
+	if (ply >= 1 && line[ply-1].cont_hist)
 		line[ply-1].cont_hist->hist[board.side][board.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
-	}
+	if (ply >= 2 && line[ply-2].cont_hist)
+		line[ply-2].cont_hist->hist[board.side][board.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
 }
 
 void update_capthist(PieceType piece, PieceType captured, Square dst, Value bonus) {


### PR DESCRIPTION
```
Elo   | 8.04 +- 4.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 5.00]
Games | N: 5618 W: 1347 L: 1217 D: 3054
Penta | [26, 603, 1424, 727, 29]
```
https://sscg13.pythonanywhere.com/test/1171/

Bench: 9414793