### PR TITLE
Use conthist for history pruning

### DIFF
--- a/engine/history.hpp
+++ b/engine/history.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "includes.hpp"
+
+struct ContHistEntry {
+	Value hist[2][6][64]; // [side][piecetype][to]
+
+	ContHistEntry() {
+		memset(hist, 0, sizeof(hist));
+	}
+};

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -556,7 +556,7 @@ Value __recurse(Board &board, int depth, Value alpha = -VALUE_INFINITE, Value be
 				 * Skip moves with very bad history scores
 				 * Depth condition is necessary to avoid overflow
 				 */
-				Value hist = history[board.side][move.src()][move.dst()];
+				Value hist = get_history(board, move, ply);
 				if (hist < -HISTORY_MARGIN * depth)
 					break;
 			}

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -2,6 +2,7 @@
 
 #include "bitboard.hpp"
 #include "eval.hpp"
+#include "history.hpp"
 #include "movegen.hpp"
 #include "ttable.hpp"
 #include <algorithm>
@@ -53,7 +54,9 @@ struct SSEntry {
 	Move move;
 	Value eval;
 	Move excl;
-	SSEntry() : move(NullMove), eval(VALUE_NONE), excl(NullMove) {}
+	ContHistEntry *cont_hist;
+
+	SSEntry() : move(NullMove), eval(VALUE_NONE), excl(NullMove), cont_hist(nullptr) {}
 };
 
 std::pair<Move, Value> search(Board &board, int64_t time = 1e9, int depth = MAX_PLY, int64_t nodes = 1e18, int quiet = 0);


### PR DESCRIPTION
```
Elo   | 6.74 +- 4.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 7014 W: 1696 L: 1560 D: 3758
Penta | [39, 786, 1730, 904, 48]
```
https://sscg13.pythonanywhere.com/test/1170/

Bench: 9682237