### PR TITLE
Add output buckets

### DIFF
--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -285,8 +285,7 @@ Value eval(Board &board) {
 
 	memcpy(bs[winbucket][binbucket].mailbox, board.mailbox, sizeof(bs[winbucket][binbucket].mailbox));
 
-	// int nbucket = (npieces - 2) / 4;
-	int nbucket = 0;
+	int nbucket = (npieces - 2) / 4;
 
 	if (board.side == WHITE) {
 		score = nnue_eval(nnue_network, bs[winbucket][binbucket].w_acc, bs[winbucket][binbucket].b_acc, nbucket);
@@ -349,11 +348,11 @@ std::array<Value, 8> debug_eval(Board &board) {
 	std::array<Value, 8> score = {};
 	if (board.side == WHITE) {
 		for (int i = 0; i < 8; i++) {
-			score[i] = nnue_eval(nnue_network, bs[winbucket][binbucket].w_acc, bs[winbucket][binbucket].b_acc, 0);
+			score[i] = nnue_eval(nnue_network, bs[winbucket][binbucket].w_acc, bs[winbucket][binbucket].b_acc, i);
 		}
 	} else {
 		for (int i = 0; i < 8; i++) {
-			score[i] = -nnue_eval(nnue_network, bs[winbucket][binbucket].b_acc, bs[winbucket][binbucket].w_acc, 0);
+			score[i] = -nnue_eval(nnue_network, bs[winbucket][binbucket].b_acc, bs[winbucket][binbucket].w_acc, i);
 		}
 	}
 

--- a/engine/nnue/network.hpp
+++ b/engine/nnue/network.hpp
@@ -5,7 +5,7 @@
 #define INPUT_SIZE 768
 #define NINPUTS 1
 #define HL_SIZE 64
-#define NBUCKETS 1
+#define NBUCKETS 8
 #define SCALE 400
 #define QA 255
 #define QB 64


### PR DESCRIPTION
```
Elo   | 25.15 +- 13.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.25, 2.89) [0.00, 10.00]
Games | N: 1204 W: 416 L: 329 D: 459
Penta | [28, 124, 236, 161, 53]
```
https://sscg13.pythonanywhere.com/test/1248/

Bench: 1364035