### PR TITLE
Do not allow IIR in singular search nodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -569,7 +569,7 @@ Value negamax(ThreadInfo &ti, int depth, Value alpha = -VALUE_INFINITE, Value be
 	MovePicker mp(board, &ti.line[ply], ply, &ti.thread_hist, tentry);
 
 	// Internal iterative reductions
-	if ((pv || cutnode) && depth > 4 && !(tentry && tentry->best_move != NullMove)) {
+	if ((pv || cutnode) && depth > 4 && !excluded && !(tentry && tentry->best_move != NullMove)) {
 		/**
 		 * In positions where we are in a node where we'd expect a TT move (i.e. PV/cutnode) and
 		 * we don't have one, it's likely that the position is not good enough to warrant a TT move.


### PR DESCRIPTION
```
Elo   | 1.78 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 11910 W: 2852 L: 2791 D: 6267
Penta | [42, 1269, 3280, 1314, 50]
```
https://ob.int0x80.ca/test/329/

Bench: 4641911