### PR TITLE
Add Chess960 support

### DIFF
--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -136,23 +136,57 @@ void Board::load_fen(std::string fen) {
 	inputIdx += 3;
 
 	// Load castling rights
+	Bitboard rooks = piece_boards[ROOK];
 	if (fen[inputIdx] != '-') {
+		char king_file = (_tzcnt_u64(piece_boards[KING] & piece_boards[OCC(WHITE)])) + 'A';
 		if (fen[inputIdx] == 'K') {
 			castling |= WHITE_OO;
 			inputIdx++;
+			Square king_square = make_square(File(king_file - 'A'), RANK_1);
+			Bitboard mask = ~(square_bits(king_square) - 1);
+			rook_pos[0] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(WHITE)]));
+		} else if (fen[inputIdx] <= 'H' && fen[inputIdx] > king_file) {
+			castling |= WHITE_OO;
+			inputIdx++;
+			rook_pos[0] = make_square(File(fen[inputIdx - 1] - 'A'), RANK_1);
 		}
+
 		if (fen[inputIdx] == 'Q') {
 			castling |= WHITE_OOO;
 			inputIdx++;
+			Square king_square = make_square(File(king_file - 'A'), RANK_1);
+			Bitboard mask = (square_bits(king_square) - 1);
+			rook_pos[1] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(WHITE)]));
+		} else if (fen[inputIdx] >= 'A' && fen[inputIdx] < king_file) {
+			castling |= WHITE_OOO;
+			inputIdx++;
+			rook_pos[1] = make_square(File(fen[inputIdx - 1] - 'A'), RANK_1);
 		}
+
 		if (fen[inputIdx] == 'k') {
 			castling |= BLACK_OO;
 			inputIdx++;
+			Square king_square = make_square(File(king_file - 'A'), RANK_8);
+			Bitboard mask = ~(square_bits(king_square) - 1);
+			rook_pos[2] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(BLACK)]));
+		} else if (fen[inputIdx] <= 'h' && fen[inputIdx] > king_file + 32) {
+			castling |= BLACK_OO;
+			inputIdx++;
+			rook_pos[2] = make_square(File(fen[inputIdx - 1] - 'a'), RANK_8);
 		}
+
 		if (fen[inputIdx] == 'q') {
 			castling |= BLACK_OOO;
 			inputIdx++;
+			Square king_square = make_square(File(king_file - 'A'), RANK_8);
+			Bitboard mask = (square_bits(king_square) - 1);
+			rook_pos[3] = Square(63 - _lzcnt_u64(rooks & mask & piece_boards[OCC(BLACK)]));
+		} else if (fen[inputIdx] >= 'a' && fen[inputIdx] < king_file + 32) {
+			castling |= BLACK_OOO;
+			inputIdx++;
+			rook_pos[3] = make_square(File(fen[inputIdx - 1] - 'a'), RANK_8);
 		}
+
 		inputIdx++;
 	} else {
 		inputIdx += 2;

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -100,7 +100,7 @@ Move Move::from_string(const std::string &str, const void *b) {
 		if ((((const Board *)b)->mailbox[src] & 7) == KING) {
 			// Check for castling
 			if (dfrc_uci) {
-				if ((board->mailbox[src] & 7) == KING && (board->mailbox[dst] & 7) == ROOK)
+				if ((board->mailbox[src] & 7) == KING && board->mailbox[dst] == (ROOK | (board->mailbox[src] & 8)))
 					return Move::make<CASTLING>(src, dst);
 				else
 					return Move(src, dst);

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -106,13 +106,13 @@ Move Move::from_string(const std::string &str, const void *b) {
 					return Move(src, dst);
 			} else {
 				if (str == "e1g1")
-					return Move::make<CASTLING>(src, board->rook_pos[1]);
-				if (str == "e1c1")
 					return Move::make<CASTLING>(src, board->rook_pos[0]);
+				if (str == "e1c1")
+					return Move::make<CASTLING>(src, board->rook_pos[1]);
 				if (str == "e8g8")
-					return Move::make<CASTLING>(src, board->rook_pos[3]);
-				if (str == "e8c8")
 					return Move::make<CASTLING>(src, board->rook_pos[2]);
+				if (str == "e8c8")
+					return Move::make<CASTLING>(src, board->rook_pos[3]);
 			}
 		} else if ((board->mailbox[src] & 7) == PAWN && dst == ((const Board *)b)->ep_square) {
 			// En passant

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -241,6 +241,10 @@ void Board::reset_board() {
 	halfmove = 0;
 	castling = 0xf;  // 1111
 	ep_square = SQ_NONE;
+	rook_pos[0] = SQ_H1;
+	rook_pos[1] = SQ_A1;
+	rook_pos[2] = SQ_H8;
+	rook_pos[3] = SQ_A8;
 
 	while (!move_hist.empty()) move_hist.pop();
 	while (!halfmove_hist.empty()) halfmove_hist.pop();

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -2,7 +2,7 @@
 #include <cctype>
 #include <random>
 
-extern bool isdfrc;
+extern bool dfrc_uci;
 
 uint64_t zobrist_square[64][15];
 uint64_t zobrist_castling[16];
@@ -47,7 +47,7 @@ std::string Move::to_string() const {
 	std::string str = "";
 	str += (char)('a' + (src() & 0b111));
 	str += (char)('1' + (src() >> 3));
-	if (!isdfrc && type() == CASTLING) {
+	if (!dfrc_uci && type() == CASTLING) {
 		if (dst() > src())
 			return str + 'g' + (char)('1' + (dst() >> 3));
 		else
@@ -99,20 +99,20 @@ Move Move::from_string(const std::string &str, const void *b) {
 	} else {
 		if ((((const Board *)b)->mailbox[src] & 7) == KING) {
 			// Check for castling
-			if (isdfrc) {
+			if (dfrc_uci) {
 				if ((board->mailbox[src] & 7) == KING && (board->mailbox[dst] & 7) == ROOK)
 					return Move::make<CASTLING>(src, dst);
 				else
 					return Move(src, dst);
 			} else {
 				if (str == "e1g1")
-					return Move::make<CASTLING>(src, SQ_H1);
+					return Move::make<CASTLING>(src, board->rook_pos[1]);
 				if (str == "e1c1")
-					return Move::make<CASTLING>(src, SQ_A1);
+					return Move::make<CASTLING>(src, board->rook_pos[0]);
 				if (str == "e8g8")
-					return Move::make<CASTLING>(src, SQ_H8);
+					return Move::make<CASTLING>(src, board->rook_pos[3]);
 				if (str == "e8c8")
-					return Move::make<CASTLING>(src, SQ_A8);
+					return Move::make<CASTLING>(src, board->rook_pos[2]);
 			}
 		} else if ((board->mailbox[src] & 7) == PAWN && dst == ((const Board *)b)->ep_square) {
 			// En passant
@@ -169,6 +169,7 @@ void Board::load_fen(std::string fen) {
 			Bitboard mask = ~(square_bits(king_square) - 1);
 			rook_pos[0] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(WHITE)]));
 		} else if (fen[inputIdx] <= 'H' && fen[inputIdx] > king_file) {
+			dfrc_uci = true;
 			castling |= WHITE_OO;
 			inputIdx++;
 			rook_pos[0] = make_square(File(fen[inputIdx - 1] - 'A'), RANK_1);
@@ -181,18 +182,21 @@ void Board::load_fen(std::string fen) {
 			Bitboard mask = (square_bits(king_square) - 1);
 			rook_pos[1] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(WHITE)]));
 		} else if (fen[inputIdx] >= 'A' && fen[inputIdx] < king_file) {
+			dfrc_uci = true;
 			castling |= WHITE_OOO;
 			inputIdx++;
 			rook_pos[1] = make_square(File(fen[inputIdx - 1] - 'A'), RANK_1);
 		}
 
+		king_file = (_tzcnt_u64(piece_boards[KING] & piece_boards[OCC(BLACK)]) & 7) + 'a';
 		if (fen[inputIdx] == 'k') {
 			castling |= BLACK_OO;
 			inputIdx++;
-			Square king_square = make_square(File(king_file - 'A'), RANK_8);
+			Square king_square = make_square(File(king_file - 'a'), RANK_8);
 			Bitboard mask = ~(square_bits(king_square) - 1);
 			rook_pos[2] = Square(_tzcnt_u64(rooks & mask & piece_boards[OCC(BLACK)]));
-		} else if (fen[inputIdx] <= 'h' && fen[inputIdx] > king_file + 32) {
+		} else if (fen[inputIdx] <= 'h' && fen[inputIdx] > king_file) {
+			dfrc_uci = true;
 			castling |= BLACK_OO;
 			inputIdx++;
 			rook_pos[2] = make_square(File(fen[inputIdx - 1] - 'a'), RANK_8);
@@ -201,10 +205,11 @@ void Board::load_fen(std::string fen) {
 		if (fen[inputIdx] == 'q') {
 			castling |= BLACK_OOO;
 			inputIdx++;
-			Square king_square = make_square(File(king_file - 'A'), RANK_8);
+			Square king_square = make_square(File(king_file - 'a'), RANK_8);
 			Bitboard mask = (square_bits(king_square) - 1);
 			rook_pos[3] = Square(63 - _lzcnt_u64(rooks & mask & piece_boards[OCC(BLACK)]));
-		} else if (fen[inputIdx] >= 'a' && fen[inputIdx] < king_file + 32) {
+		} else if (fen[inputIdx] >= 'a' && fen[inputIdx] < king_file) {
+			dfrc_uci = true;
 			castling |= BLACK_OOO;
 			inputIdx++;
 			rook_pos[3] = make_square(File(fen[inputIdx - 1] - 'a'), RANK_8);
@@ -305,13 +310,13 @@ std::string Board::get_fen() const {
 		res += '-';
 	} else {
 		if (castling & WHITE_OO)
-			res += 'K';
+			res += dfrc_uci ? (rook_pos[0] + 'A') : 'K';
 		if (castling & WHITE_OOO)
-			res += 'Q';
+			res += dfrc_uci ? (rook_pos[1] + 'A') : 'Q';
 		if (castling & BLACK_OO)
-			res += 'k';
+			res += dfrc_uci ? (rook_pos[2] & 7) + 'a' : 'k';
 		if (castling & BLACK_OOO)
-			res += 'q';
+			res += dfrc_uci ? (rook_pos[3] & 7) + 'a' : 'q';
 	}
 	
 	// En passant square
@@ -622,13 +627,13 @@ void Board::make_move(Move move) {
 		piece_hashes[mailbox[move.dst()]] ^= zobrist_square[move.dst()][mailbox[move.dst()]];
 
 		if (piece == ROOK) {
-			if (move.dst() == SQ_A1)
+			if (move.dst() == rook_pos[1])
 				castling &= ~WHITE_OOO;
-			else if (move.dst() == SQ_H1)
+			else if (move.dst() == rook_pos[0])
 				castling &= ~WHITE_OO;
-			else if (move.dst() == SQ_A8)
+			else if (move.dst() == rook_pos[3])
 				castling &= ~BLACK_OOO;
-			else if (move.dst() == SQ_H8)
+			else if (move.dst() == rook_pos[2])
 				castling &= ~BLACK_OO;
 		}
 
@@ -681,8 +686,8 @@ void Board::make_move(Move move) {
 		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
 		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
 		mailbox[king_from] = NO_PIECE;
-		mailbox[king_to] = king_piece;
 		mailbox[rook_from] = NO_PIECE;
+		mailbox[king_to] = king_piece;
 		mailbox[rook_to] = rook_piece;
 		piece_boards[KING] ^= square_bits(king_from) ^ square_bits(king_to);
 		piece_boards[ROOK] ^= square_bits(rook_from) ^ square_bits(rook_to);
@@ -702,13 +707,13 @@ void Board::make_move(Move move) {
 		if (piece == KING) {
 			castling &= ~((WHITE_OO | WHITE_OOO) << (side << 1));
 		} else if (piece == ROOK) {
-			if (move.src() == SQ_A1)
+			if (move.src() == rook_pos[1])
 				castling &= ~WHITE_OOO;
-			else if (move.src() == SQ_H1)
+			else if (move.src() == rook_pos[0])
 				castling &= ~WHITE_OO;
-			else if (move.src() == SQ_A8)
+			else if (move.src() == rook_pos[3])
 				castling &= ~BLACK_OOO;
-			else if (move.src() == SQ_H8)
+			else if (move.src() == rook_pos[2])
 				castling &= ~BLACK_OO;
 		} else {
 			// Set EP square if applicable
@@ -864,8 +869,8 @@ void Board::unmake_move() {
 		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
 		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
 		mailbox[king_to] = NO_PIECE;
-		mailbox[king_from] = king_piece;
 		mailbox[rook_to] = NO_PIECE;
+		mailbox[king_from] = king_piece;
 		mailbox[rook_from] = rook_piece;
 		piece_boards[KING] ^= square_bits(king_from) ^ square_bits(king_to);
 		piece_boards[ROOK] ^= square_bits(rook_from) ^ square_bits(rook_to);

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -657,10 +657,10 @@ void Board::make_move(Move move) {
 		zobrist ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
 		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
 		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
-		mailbox[king_to] = king_piece;
 		mailbox[king_from] = NO_PIECE;
-		mailbox[rook_to] = rook_piece;
+		mailbox[king_to] = king_piece;
 		mailbox[rook_from] = NO_PIECE;
+		mailbox[rook_to] = rook_piece;
 		piece_boards[KING] ^= square_bits(king_from) ^ square_bits(king_to);
 		piece_boards[ROOK] ^= square_bits(rook_from) ^ square_bits(rook_to);
 		piece_boards[OCC(side)] ^= (square_bits(king_from) ^ square_bits(king_to)) ^ (square_bits(rook_from) ^ square_bits(rook_to));
@@ -747,7 +747,7 @@ void Board::make_move(Move move) {
 			else
 				std::cout << ' ';
 		}
-		std::cout << (!side ? "black " : "white ") << move.to_string() << std::endl;
+		std::cout << "Sanity check failed after make " << move.to_string() << std::endl;
 		for (int i = 0; i < 64; i++) {
 			std::cout << after[i];
 			if (i % 8 == 7)
@@ -761,8 +761,10 @@ void Board::make_move(Move move) {
 }
 
 void Board::unmake_move() {
-	// char before[64];
-	// sanity_check(before);
+#ifdef SANCHECK
+	char before[64];
+	sanity_check(before);
+#endif
 
 #ifdef HASHCHECK
 	uint64_t old_hash = zobrist;
@@ -838,13 +840,13 @@ void Board::unmake_move() {
 		zobrist ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
 		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
 		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
-		mailbox[king_from] = king_piece;
 		mailbox[king_to] = NO_PIECE;
-		mailbox[rook_from] = rook_piece;
+		mailbox[king_from] = king_piece;
 		mailbox[rook_to] = NO_PIECE;
-		piece_boards[KING] ^= square_bits(king_from) | square_bits(king_to);
-		piece_boards[ROOK] ^= square_bits(rook_from) | square_bits(rook_to);
-		piece_boards[OCC(side)] ^= square_bits(king_from) | square_bits(king_to) | square_bits(rook_from) | square_bits(rook_to);
+		mailbox[rook_from] = rook_piece;
+		piece_boards[KING] ^= square_bits(king_from) ^ square_bits(king_to);
+		piece_boards[ROOK] ^= square_bits(rook_from) ^ square_bits(rook_to);
+		piece_boards[OCC(side)] ^= (square_bits(king_from) ^ square_bits(king_to)) ^ (square_bits(rook_from) ^ square_bits(rook_to));
 	} else {
 		// Get piece that is moving
 		uint8_t piece = mailbox[move.dst()] & 0b111;
@@ -903,25 +905,27 @@ void Board::unmake_move() {
 	}
 #endif
 
-	// char after[64];
-	// if (sanity_check(after)) {
-	// 	for (int i = 0; i < 64; i++) {
-	// 		std::cout << before[i];
-	// 		if (i % 8 == 7)
-	// 			std::cout << '\n';
-	// 		else
-	// 			std::cout << ' ';
-	// 	}
-	// 	std::cout << "Unmaking: " << move.to_string() << std::endl;
-	// 	for (int i = 0; i < 64; i++) {
-	// 		std::cout << after[i];
-	// 		if (i % 8 == 7)
-	// 			std::cout << '\n';
-	// 		else
-	// 			std::cout << ' ';
-	// 	}
-	// 	abort();
-	// }
+#ifdef SANCHECK
+	char after[64];
+	if (sanity_check(after)) {
+		for (int i = 0; i < 64; i++) {
+			std::cout << before[i];
+			if (i % 8 == 7)
+				std::cout << '\n';
+			else
+				std::cout << ' ';
+		}
+		std::cout << "Sanity check failed after unmake " << move.to_string() << " from " << (!side ? "black " : "white ") << std::endl;
+		for (int i = 0; i < 64; i++) {
+			std::cout << after[i];
+			if (i % 8 == 7)
+				std::cout << '\n';
+			else
+				std::cout << ' ';
+		}
+		abort();
+	}
+#endif
 }
 
 void Board::recompute_hash() {

--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -565,10 +565,18 @@ void Board::make_move(Move move) {
 
 #ifdef HASHCHECK
 	uint64_t old_hash = zobrist;
+	uint64_t old_piece_hashes[15];
+	memcpy(old_piece_hashes, piece_hashes, sizeof(piece_hashes));
 	recompute_hash();
 	if (old_hash != zobrist) {
 		std::cerr << "Hash mismatch before move: expected " << zobrist << " got " << old_hash << '\n';
 		abort();
+	}
+	for (int i = 0; i < 15; i++) {
+		if (old_piece_hashes[i] != piece_hashes[i]) {
+			std::cerr << "Piece hash mismatch before move for piece " << i << ": expected " << piece_hashes[i] << " got " << old_piece_hashes[i] << '\n';
+			abort();
+		}
 	}
 #endif
 
@@ -578,7 +586,7 @@ void Board::make_move(Move move) {
 	Square tmp_ep_square = SQ_NONE;
 
 	// Handle captures
-	if (move.data != 0 && (piece_boards[OPPOCC(side)] & square_bits(move.dst()))) { // If opposite occupancy bit set on destination (capture)
+	if (move.data != 0 && is_capture(move)) {
 		// Remove whatever piece it was
 		uint8_t piece = mailbox[move.dst()] & 0b111;
 		piece_boards[piece] ^= square_bits(move.dst());
@@ -629,67 +637,29 @@ void Board::make_move(Move move) {
 		piece_boards[OCC(side)] ^= square_bits(move.src()) | square_bits(move.dst());
 		piece_boards[OPPOCC(side)] ^= square_bits(Rank(move.src() >> 3), File(move.dst() & 0b111));
 	} else if (move.type() == CASTLING) {
-		// Calculate where the rook is
-		Bitboard rook_mask;
-		if (move.data == 0b1100000100000110) {
-			// White O-O
-			mailbox[SQ_E1] = NO_PIECE;
-			mailbox[SQ_G1] = Piece(WHITE_KING);
-			mailbox[SQ_H1] = NO_PIECE;
-			mailbox[SQ_F1] = Piece(WHITE_ROOK);
-			piece_boards[OCC(WHITE)] ^= square_bits(SQ_E1) | square_bits(SQ_G1) | square_bits(SQ_H1) | square_bits(SQ_F1);
-			piece_boards[KING] ^= square_bits(SQ_E1) | square_bits(SQ_G1);
-			piece_boards[ROOK] ^= square_bits(SQ_H1) | square_bits(SQ_F1);
-			zobrist ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_G1][Piece(WHITE_KING)];
-			zobrist ^= zobrist_square[SQ_H1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_F1][Piece(WHITE_ROOK)];
-			piece_hashes[WHITE_KING] ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_G1][Piece(WHITE_KING)];
-			piece_hashes[WHITE_ROOK] ^= zobrist_square[SQ_H1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_F1][Piece(WHITE_ROOK)];
-		} else if (move.data == 0b1100000100000010) {
-			// White O-O-O
-			mailbox[SQ_E1] = NO_PIECE;
-			mailbox[SQ_C1] = Piece(WHITE_KING);
-			mailbox[SQ_A1] = NO_PIECE;
-			mailbox[SQ_D1] = Piece(WHITE_ROOK);
-			piece_boards[OCC(WHITE)] ^= square_bits(SQ_E1) | square_bits(SQ_C1) | square_bits(SQ_A1) | square_bits(SQ_D1);
-			piece_boards[KING] ^= square_bits(SQ_E1) | square_bits(SQ_C1);
-			piece_boards[ROOK] ^= square_bits(SQ_A1) | square_bits(SQ_D1);
-			zobrist ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_C1][Piece(WHITE_KING)];
-			zobrist ^= zobrist_square[SQ_A1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_D1][Piece(WHITE_ROOK)];
-			piece_hashes[WHITE_KING] ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_C1][Piece(WHITE_KING)];
-			piece_hashes[WHITE_ROOK] ^= zobrist_square[SQ_A1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_D1][Piece(WHITE_ROOK)];
-		} else if (move.data == 0b1100111100111110) {
-			// Black O-O
-			mailbox[SQ_E8] = NO_PIECE;
-			mailbox[SQ_G8] = Piece(BLACK_KING);
-			mailbox[SQ_H8] = NO_PIECE;
-			mailbox[SQ_F8] = Piece(BLACK_ROOK);
-			piece_boards[OCC(BLACK)] ^= square_bits(SQ_E8) | square_bits(SQ_G8) | square_bits(SQ_H8) | square_bits(SQ_F8);
-			piece_boards[KING] ^= square_bits(SQ_E8) | square_bits(SQ_G8);
-			piece_boards[ROOK] ^= square_bits(SQ_H8) | square_bits(SQ_F8);
-			zobrist ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_G8][Piece(BLACK_KING)];
-			zobrist ^= zobrist_square[SQ_H8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_F8][Piece(BLACK_ROOK)];
-			piece_hashes[BLACK_KING] ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_G8][Piece(BLACK_KING)];
-			piece_hashes[BLACK_ROOK] ^= zobrist_square[SQ_H8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_F8][Piece(BLACK_ROOK)];
-		} else if (move.data == 0b1100111100111010) {
-			// Black O-O-O
-			mailbox[SQ_E8] = NO_PIECE;
-			mailbox[SQ_C8] = Piece(BLACK_KING);
-			mailbox[SQ_A8] = NO_PIECE;
-			mailbox[SQ_D8] = Piece(BLACK_ROOK);
-			piece_boards[OCC(BLACK)] ^= square_bits(SQ_E8) | square_bits(SQ_C8) | square_bits(SQ_A8) | square_bits(SQ_D8);
-			piece_boards[KING] ^= square_bits(SQ_E8) | square_bits(SQ_C8);
-			piece_boards[ROOK] ^= square_bits(SQ_A8) | square_bits(SQ_D8);
-			zobrist ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_C8][Piece(BLACK_KING)];
-			zobrist ^= zobrist_square[SQ_A8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_D8][Piece(BLACK_ROOK)];
-			piece_hashes[BLACK_KING] ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_C8][Piece(BLACK_KING)];
-			piece_hashes[BLACK_ROOK] ^= zobrist_square[SQ_A8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_D8][Piece(BLACK_ROOK)];
-		} else {
-			std::cerr << "Il faut que tu meures" << std::endl;
-			volatile int *p = 0;
-			*p = move.type();
-		}
 		// Remove castling rights
 		castling &= ~((WHITE_OO | WHITE_OOO) << (side + side));
+
+		Square king_from = move.src();
+		Square king_to = move.dst() > move.src() ? make_square(FILE_G, Rank(king_from >> 3)) : make_square(FILE_C, Rank(king_from >> 3));
+
+		Square rook_from = move.dst();
+		Square rook_to = move.dst() > move.src() ? make_square(FILE_F, Rank(rook_from >> 3)) : make_square(FILE_D, Rank(rook_from >> 3));
+
+		Piece king_piece = Piece(KING + (side << 3));
+		Piece rook_piece = Piece(ROOK + (side << 3));
+
+		zobrist ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
+		zobrist ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
+		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
+		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
+		mailbox[king_to] = king_piece;
+		mailbox[king_from] = NO_PIECE;
+		mailbox[rook_to] = rook_piece;
+		mailbox[rook_from] = NO_PIECE;
+		piece_boards[KING] ^= square_bits(king_from) ^ square_bits(king_to);
+		piece_boards[ROOK] ^= square_bits(rook_from) ^ square_bits(rook_to);
+		piece_boards[OCC(side)] ^= (square_bits(king_from) ^ square_bits(king_to)) ^ (square_bits(rook_from) ^ square_bits(rook_to));
 	} else {
 		// Get piece that is moving
 		uint8_t piece = mailbox[move.src()] & 0b111;
@@ -745,12 +715,21 @@ void Board::make_move(Move move) {
 
 #ifdef HASHCHECK
 	old_hash = zobrist;
+	memcpy(old_piece_hashes, piece_hashes, sizeof(piece_hashes));
 	recompute_hash();
 	if (zobrist != old_hash) {
 		print_board();
 		std::cerr << "Hash mismatch after make: expected " << old_hash << " got " << zobrist << std::endl;
 		std::cerr << "Move: " << move.to_string() << std::endl;
 		abort();
+	}
+	for (int i = 0; i < 15; i++) {
+		if (old_piece_hashes[i] != piece_hashes[i]) {
+			print_board();
+			std::cerr << "Piece hash mismatch after make for piece " << i << ": expected " << old_piece_hashes[i] << " got " << piece_hashes[i] << std::endl;
+			std::cerr << "Move: " << move.to_string() << std::endl;
+			abort();
+		}
 	}
 #endif
 
@@ -783,10 +762,18 @@ void Board::unmake_move() {
 
 #ifdef HASHCHECK
 	uint64_t old_hash = zobrist;
+	uint64_t old_piece_hashes[15];
+	memcpy(old_piece_hashes, piece_hashes, sizeof(piece_hashes));
 	recompute_hash();
 	if (old_hash != zobrist) {
 		std::cerr << "Hash mismatch before unmake: expected " << zobrist << " got " << old_hash << '\n';
 		abort();
+	}
+	for (int i = 0; i < 15; i++) {
+		if (old_piece_hashes[i] != piece_hashes[i]) {
+			std::cerr << "Piece hash mismatch before unmake for piece " << i << ": expected " << piece_hashes[i] << " got " << old_piece_hashes[i] << '\n';
+			abort();
+		}
 	}
 #endif
 
@@ -834,63 +821,26 @@ void Board::unmake_move() {
 		piece_boards[OCC(side)] ^= square_bits(move.src()) | square_bits(move.dst());
 		piece_boards[OPPOCC(side)] ^= square_bits(Rank(move.src() >> 3), File(move.dst() & 0b111));
 	} else if (move.type() == CASTLING) {
-		if (move.data == 0b1100000100000110) {
-			// White O-O
-			mailbox[SQ_G1] = NO_PIECE;
-			mailbox[SQ_E1] = Piece(WHITE_KING);
-			mailbox[SQ_F1] = NO_PIECE;
-			mailbox[SQ_H1] = Piece(WHITE_ROOK);
-			piece_boards[OCC(WHITE)] ^= square_bits(SQ_E1) | square_bits(SQ_G1) | square_bits(SQ_H1) | square_bits(SQ_F1);
-			piece_boards[KING] ^= square_bits(SQ_E1) | square_bits(SQ_G1);
-			piece_boards[ROOK] ^= square_bits(SQ_H1) | square_bits(SQ_F1);
-			zobrist ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_G1][Piece(WHITE_KING)];
-			zobrist ^= zobrist_square[SQ_H1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_F1][Piece(WHITE_ROOK)];
-			piece_hashes[WHITE_KING] ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_G1][Piece(WHITE_KING)];
-			piece_hashes[WHITE_ROOK] ^= zobrist_square[SQ_H1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_F1][Piece(WHITE_ROOK)];
-		} else if (move.data == 0b1100000100000010) {
-			// White O-O-O
-			mailbox[SQ_C1] = NO_PIECE;
-			mailbox[SQ_E1] = Piece(WHITE_KING);
-			mailbox[SQ_D1] = NO_PIECE;
-			mailbox[SQ_A1] = Piece(WHITE_ROOK);
-			piece_boards[OCC(WHITE)] ^= square_bits(SQ_E1) | square_bits(SQ_C1) | square_bits(SQ_A1) | square_bits(SQ_D1);
-			piece_boards[KING] ^= square_bits(SQ_E1) | square_bits(SQ_C1);
-			piece_boards[ROOK] ^= square_bits(SQ_A1) | square_bits(SQ_D1);
-			zobrist ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_C1][Piece(WHITE_KING)];
-			zobrist ^= zobrist_square[SQ_A1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_D1][Piece(WHITE_ROOK)];
-			piece_hashes[WHITE_KING] ^= zobrist_square[SQ_E1][Piece(WHITE_KING)] ^ zobrist_square[SQ_C1][Piece(WHITE_KING)];
-			piece_hashes[WHITE_ROOK] ^= zobrist_square[SQ_A1][Piece(WHITE_ROOK)] ^ zobrist_square[SQ_D1][Piece(WHITE_ROOK)];
-		} else if (move.data == 0b1100111100111110) {
-			// Black O-O
-			mailbox[SQ_G8] = NO_PIECE;
-			mailbox[SQ_E8] = Piece(BLACK_KING);
-			mailbox[SQ_F8] = NO_PIECE;
-			mailbox[SQ_H8] = Piece(BLACK_ROOK);
-			piece_boards[OCC(BLACK)] ^= square_bits(SQ_E8) | square_bits(SQ_G8) | square_bits(SQ_H8) | square_bits(SQ_F8);
-			piece_boards[KING] ^= square_bits(SQ_E8) | square_bits(SQ_G8);
-			piece_boards[ROOK] ^= square_bits(SQ_H8) | square_bits(SQ_F8);
-			zobrist ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_G8][Piece(BLACK_KING)];
-			zobrist ^= zobrist_square[SQ_H8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_F8][Piece(BLACK_ROOK)];
-			piece_hashes[BLACK_KING] ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_G8][Piece(BLACK_KING)];
-			piece_hashes[BLACK_ROOK] ^= zobrist_square[SQ_H8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_F8][Piece(BLACK_ROOK)];
-		} else if (move.data == 0b1100111100111010) {
-			// Black O-O-O
-			mailbox[SQ_C8] = NO_PIECE;
-			mailbox[SQ_E8] = Piece(BLACK_KING);
-			mailbox[SQ_D8] = NO_PIECE;
-			mailbox[SQ_A8] = Piece(BLACK_ROOK);
-			piece_boards[OCC(BLACK)] ^= square_bits(SQ_E8) | square_bits(SQ_C8) | square_bits(SQ_A8) | square_bits(SQ_D8);
-			piece_boards[KING] ^= square_bits(SQ_E8) | square_bits(SQ_C8);
-			piece_boards[ROOK] ^= square_bits(SQ_A8) | square_bits(SQ_D8);
-			zobrist ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_C8][Piece(BLACK_KING)];
-			zobrist ^= zobrist_square[SQ_A8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_D8][Piece(BLACK_ROOK)];
-			piece_hashes[BLACK_KING] ^= zobrist_square[SQ_E8][Piece(BLACK_KING)] ^ zobrist_square[SQ_C8][Piece(BLACK_KING)];
-			piece_hashes[BLACK_ROOK] ^= zobrist_square[SQ_A8][Piece(BLACK_ROOK)] ^ zobrist_square[SQ_D8][Piece(BLACK_ROOK)];
-		} else {
-			std::cerr << "Il faut que tu meures" << std::endl;
-			volatile int *p = 0;
-			*p = move.type();
-		}
+		Square king_from = move.src();
+		Square king_to = move.dst() > move.src() ? make_square(FILE_G, Rank(king_from >> 3)) : make_square(FILE_C, Rank(king_from >> 3));
+
+		Square rook_from = move.dst();
+		Square rook_to = move.dst() > move.src() ? make_square(FILE_F, Rank(rook_from >> 3)) : make_square(FILE_D, Rank(rook_from >> 3));
+
+		Piece king_piece = Piece(KING + (side << 3));
+		Piece rook_piece = Piece(ROOK + (side << 3));
+
+		zobrist ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
+		zobrist ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
+		piece_hashes[king_piece] ^= zobrist_square[king_from][king_piece] ^ zobrist_square[king_to][king_piece];
+		piece_hashes[rook_piece] ^= zobrist_square[rook_from][rook_piece] ^ zobrist_square[rook_to][rook_piece];
+		mailbox[king_from] = king_piece;
+		mailbox[king_to] = NO_PIECE;
+		mailbox[rook_from] = rook_piece;
+		mailbox[rook_to] = NO_PIECE;
+		piece_boards[KING] ^= square_bits(king_from) | square_bits(king_to);
+		piece_boards[ROOK] ^= square_bits(rook_from) | square_bits(rook_to);
+		piece_boards[OCC(side)] ^= square_bits(king_from) | square_bits(king_to) | square_bits(rook_from) | square_bits(rook_to);
 	} else {
 		// Get piece that is moving
 		uint8_t piece = mailbox[move.dst()] & 0b111;
@@ -931,12 +881,21 @@ void Board::unmake_move() {
 
 #ifdef HASHCHECK
 	old_hash = zobrist;
+	memcpy(old_piece_hashes, piece_hashes, sizeof(piece_hashes));
 	recompute_hash();
 	if (zobrist != old_hash) {
 		print_board();
 		std::cerr << "Hash mismatch after unmake: expected " << old_hash << " got " << zobrist << std::endl;
 		std::cerr << "Move: " << move.to_string() << std::endl;
 		abort();
+	}
+	for (int i = 0; i < 15; i++) {
+		if (old_piece_hashes[i] != piece_hashes[i]) {
+			print_board();
+			std::cerr << "Piece hash mismatch after unmake for piece " << i << ": expected " << old_piece_hashes[i] << " got " << piece_hashes[i] << std::endl;
+			std::cerr << "Move: " << move.to_string() << std::endl;
+			abort();
+		}
 	}
 #endif
 

--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -70,6 +70,7 @@ struct Board {
 	uint8_t halfmove = 0;
 	uint8_t castling = 0xf; // 1111
 	Square ep_square = SQ_NONE;
+	Square rook_pos[4];
 	uint64_t zobrist = 0;
 	uint64_t piece_hashes[15] = {};
 	pzstd::vector<uint64_t, 1024> hash_hist;

--- a/engine/includes.hpp
+++ b/engine/includes.hpp
@@ -113,7 +113,7 @@ inline constexpr Rank operator++(Rank &rank, int) {
 	return rank = Rank(rank + 1);
 }
 
-enum Square : uint16_t {
+enum Square : uint8_t {
 	SQ_A1, SQ_B1, SQ_C1, SQ_D1, SQ_E1, SQ_F1, SQ_G1, SQ_H1,
 	SQ_A2, SQ_B2, SQ_C2, SQ_D2, SQ_E2, SQ_F2, SQ_G2, SQ_H2,
 	SQ_A3, SQ_B3, SQ_C3, SQ_D3, SQ_E3, SQ_F3, SQ_G3, SQ_H3,

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -15,7 +15,7 @@
 
 // Options
 size_t TT_SIZE = DEFAULT_TT_SIZE;
-bool quiet = false, online = false;
+bool quiet = false, online = false, isdfrc = false;
 
 ThreadInfo *tis;
 
@@ -30,6 +30,7 @@ void run_uci() {
 			std::cout << "option name Hash type spin default 16 min 1 max " << MAX_TT << std::endl;
 			std::cout << "option name Threads type spin default 1 min 1 max " << MAX_THREADS << std::endl;
 			std::cout << "option name Quiet type check default false" << std::endl;
+			std::cout << "option name UCI_Chess960 type check default false" << std::endl;
 			std::cout << "uciok" << std::endl;
 		} else if (command == "icu") {
 			return; // exit uci mode
@@ -67,6 +68,8 @@ void run_uci() {
 				tis = new ThreadInfo[num_threads];
 				for (int i = 0; i < num_threads; i++) tis[i].set_bs();
 				std::cout << "info string Using " << num_threads << " threads" << std::endl;
+			} else if (optionname == "UCI_Chess960") {
+				isdfrc = (optionvalue == "true");
 			}
 		} else if (command == "ucinewgame") {
 			stop_search = true;

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -15,7 +15,7 @@
 
 // Options
 size_t TT_SIZE = DEFAULT_TT_SIZE;
-bool quiet = false, online = false, isdfrc = false;
+bool quiet = false, online = false, dfrc_uci = false;
 
 ThreadInfo *tis;
 
@@ -69,7 +69,7 @@ void run_uci() {
 				for (int i = 0; i < num_threads; i++) tis[i].set_bs();
 				std::cout << "info string Using " << num_threads << " threads" << std::endl;
 			} else if (optionname == "UCI_Chess960") {
-				isdfrc = (optionvalue == "true");
+				dfrc_uci = (optionvalue == "true");
 			}
 		} else if (command == "ucinewgame") {
 			stop_search = true;

--- a/engine/movegen.cpp
+++ b/engine/movegen.cpp
@@ -396,28 +396,53 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 		return;
 	int sq = _tzcnt_u64(piece);
 	// Castling
-	if (board.side == WHITE && !board.control(SQ_E1, BLACK)) {
+	Bitboard occs = board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)];
+	if (board.side == WHITE && !board.control(sq, BLACK)) {
 		if (board.castling & WHITE_OO) {
-			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_F1) | square_bits(SQ_G1))) &&
-				!board.control(SQ_F1, BLACK))
-				moves.push_back(Move::make<CASTLING>(SQ_E1, board.rook_pos[0]));
+			Bitboard mask = rook_blockers[sq][board.rook_pos[0]] | square_bits(SQ_F1);
+			if (mask & occs)
+				goto skip_white_oo;
+			for (Square s = Square(sq + 1); s <= SQ_G1; s++) {
+				if (board.control(s, BLACK))
+					goto skip_white_oo;
+			}
+			moves.push_back(Move::make<CASTLING>(sq, board.rook_pos[0]));
 		}
+	skip_white_oo:
 		if (board.castling & WHITE_OOO) {
-			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_D1) | square_bits(SQ_C1) | square_bits(SQ_B1))) &&
-				!board.control(SQ_D1, BLACK))
-				moves.push_back(Move::make<CASTLING>(SQ_E1, board.rook_pos[1]));
+			Bitboard mask = rook_blockers[sq][board.rook_pos[1]] | square_bits(SQ_D1);
+			if (mask & occs)
+				goto skip_white_ooo;
+			for (Square s = SQ_C1; s < sq; s++) {
+				if (board.control(s, BLACK))
+					goto skip_white_ooo;
+			}
+			moves.push_back(Move::make<CASTLING>(sq, board.rook_pos[1]));
 		}
-	} else if (board.side == BLACK && !board.control(SQ_E8, WHITE)) {
+	skip_white_ooo:;
+	} else if (board.side == BLACK && !board.control(sq, WHITE)) {
 		if (board.castling & BLACK_OO) {
-			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_F8) | square_bits(SQ_G8))) &&
-				!board.control(SQ_F8, WHITE))
-				moves.push_back(Move::make<CASTLING>(SQ_E8, board.rook_pos[2]));
+			Bitboard mask = rook_blockers[sq][board.rook_pos[2]] | square_bits(SQ_F8);
+			if (mask & occs)
+				goto skip_black_oo;
+			for (Square s = Square(sq + 1); s <= SQ_G8; s++) {
+				if (board.control(s, WHITE))
+					goto skip_black_oo;
+			}
+			moves.push_back(Move::make<CASTLING>(sq, board.rook_pos[2]));
 		}
+	skip_black_oo:
 		if (board.castling & BLACK_OOO) {
-			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_D8) | square_bits(SQ_C8) | square_bits(SQ_B8))) &&
-				!board.control(SQ_D8, WHITE))
-				moves.push_back(Move::make<CASTLING>(SQ_E8, board.rook_pos[3]));
+			Bitboard mask = rook_blockers[sq][board.rook_pos[3]] | square_bits(SQ_D8);
+			if (mask & occs)
+				goto skip_black_ooo;
+			for (Square s = SQ_C8; s < sq; s++) {
+				if (board.control(s, WHITE))
+					goto skip_black_ooo;
+			}
+			moves.push_back(Move::make<CASTLING>(sq, board.rook_pos[3]));
 		}
+	skip_black_ooo:;
 	}
 	// Normal moves
 	Bitboard dsts = king_movetable[sq] & ~board.piece_boards[OCC(board.side)];
@@ -872,7 +897,7 @@ bool Board::is_pseudolegal(Move move) const {
 		return false;
 
 	// Cannot take our own piece
-	if (mailbox[move.dst()] != NO_PIECE && (mailbox[move.dst()] >> 3) == side)
+	if (move.type() != CASTLING && piece_boards[OCC(side)] & square_bits(move.dst()))
 		return false;
 
 	if ((move.type() == PROMOTION || move.type() == EN_PASSANT) && (mailbox[move.src()] & 7) != PAWN)
@@ -941,21 +966,29 @@ bool Board::is_pseudolegal(Move move) const {
 
 			Bitboard mask = 0;
 			if (rights_idx == 0b00) {
-				if (control(SQ_F1, BLACK))
-					return false;
-				mask = rook_blockers[SQ_E1][SQ_H1];
+				for (Square s = Square(move.src() + 1); s <= SQ_G1; s++) {
+					if (control(s, BLACK))
+						return false;
+				}
+				mask = rook_blockers[move.src()][move.dst()] | square_bits(SQ_F1);
 			} else if (rights_idx == 0b01) {
-				if (control(SQ_D1, BLACK))
-					return false;
-				mask = rook_blockers[SQ_E1][SQ_A1];
+				for (Square s = SQ_C1; s < move.src(); s++) {
+					if (control(s, BLACK))
+						return false;
+				}
+				mask = rook_blockers[move.src()][move.dst()] | square_bits(SQ_D1);
 			} else if (rights_idx == 0b10) {
-				if (control(SQ_F8, WHITE))
-					return false;
-				mask = rook_blockers[SQ_E8][SQ_H8];
+				for (Square s = Square(move.src() + 1); s <= SQ_G8; s++) {
+					if (control(s, WHITE))
+						return false;
+				}
+				mask = rook_blockers[move.src()][move.dst()] | square_bits(SQ_F8);
 			} else if (rights_idx == 0b11) {
-				if (control(SQ_D8, WHITE))
-					return false;
-				mask = rook_blockers[SQ_E8][SQ_A8];
+				for (Square s = SQ_C8; s < move.src(); s++) {
+					if (control(s, WHITE))
+						return false;
+				}
+				mask = rook_blockers[move.src()][move.dst()] | square_bits(SQ_D8);
 			}
 			return (mask & (piece_boards[OCC(WHITE)] | piece_boards[OCC(BLACK)])) == 0;
 		} else [[likely]] {

--- a/engine/movegen.cpp
+++ b/engine/movegen.cpp
@@ -400,23 +400,23 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 		if (board.castling & WHITE_OO) {
 			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_F1) | square_bits(SQ_G1))) &&
 				!board.control(SQ_F1, BLACK))
-				moves.push_back(Move::make<CASTLING>(SQ_E1, SQ_G1));
+				moves.push_back(Move::make<CASTLING>(SQ_E1, board.rook_pos[0]));
 		}
 		if (board.castling & WHITE_OOO) {
 			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_D1) | square_bits(SQ_C1) | square_bits(SQ_B1))) &&
 				!board.control(SQ_D1, BLACK))
-				moves.push_back(Move::make<CASTLING>(SQ_E1, SQ_C1));
+				moves.push_back(Move::make<CASTLING>(SQ_E1, board.rook_pos[1]));
 		}
 	} else if (board.side == BLACK && !board.control(SQ_E8, WHITE)) {
 		if (board.castling & BLACK_OO) {
 			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_F8) | square_bits(SQ_G8))) &&
 				!board.control(SQ_F8, WHITE))
-				moves.push_back(Move::make<CASTLING>(SQ_E8, SQ_G8));
+				moves.push_back(Move::make<CASTLING>(SQ_E8, board.rook_pos[2]));
 		}
 		if (board.castling & BLACK_OOO) {
 			if (!((board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)]) & (square_bits(SQ_D8) | square_bits(SQ_C8) | square_bits(SQ_B8))) &&
 				!board.control(SQ_D8, WHITE))
-				moves.push_back(Move::make<CASTLING>(SQ_E8, SQ_C8));
+				moves.push_back(Move::make<CASTLING>(SQ_E8, board.rook_pos[3]));
 		}
 	}
 	// Normal moves

--- a/engine/movegen.cpp
+++ b/engine/movegen.cpp
@@ -14,6 +14,7 @@ Bitboard rook_blockers[64][64];
 Bitboard bishop_blockers[64][64];
 Bitboard rook_blockers_pure[64][64];
 Bitboard bishop_blockers_pure[64][64];
+Bitboard castle_blockers[64][64];
 
 MagicEntry rook_magics[64];
 MagicEntry bishop_magics[64];
@@ -68,6 +69,7 @@ void gen_rook_moves(int sq, Bitboard piece) {
 			rook_blockers_pure[dst][sq] = rook_blockers_pure[sq][dst] = rook_blockers[sq][dst];
 		}
 	}
+	rook_blockers[sq][sq] = 0;
 }
 
 void gen_bishop_moves(int sq, Bitboard piece) {
@@ -129,6 +131,7 @@ void gen_bishop_moves(int sq, Bitboard piece) {
 			bishop_blockers_pure[dst][sq] = bishop_blockers_pure[sq][dst] = bishop_blockers[sq][dst];
 		}
 	}
+	bishop_blockers[sq][sq] = 0;
 }
 
 // This function is called before main()
@@ -191,6 +194,24 @@ __attribute__((constructor)) void init_movetables() {
 			mask &= ~Rank8Bits;
 		bishop_magics[i].mask = mask;
 		gen_bishop_moves(i, piece);
+	}
+
+	// Generate castling blocker masks
+	for (Square king = SQ_A1; king <= SQ_H1; king++) {
+		for (Square rook = SQ_A1; rook <= SQ_H1; rook++) {
+			if (king == rook)
+				continue;
+			if (king < rook) {
+				// Kingside castling
+				castle_blockers[king][rook] = rook_blockers[king][SQ_G1] | rook_blockers[rook][SQ_F1] | square_bits(SQ_F1) | square_bits(SQ_G1);
+				castle_blockers[king][rook] &= ~(square_bits(rook) | square_bits(king));
+				castle_blockers[king + SQ_A8][rook + SQ_A8] = castle_blockers[king][rook] << 56;
+			} else {
+				castle_blockers[king][rook] = rook_blockers[king][SQ_C1] | rook_blockers[rook][SQ_D1] | square_bits(SQ_C1) | square_bits(SQ_D1);
+				castle_blockers[king][rook] &= ~(square_bits(rook) | square_bits(king));
+				castle_blockers[king + SQ_A8][rook + SQ_A8] = castle_blockers[king][rook] << 56;
+			}
+		}
 	}
 }
 
@@ -399,8 +420,7 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 	Bitboard occs = board.piece_boards[OCC(WHITE)] | board.piece_boards[OCC(BLACK)];
 	if (board.side == WHITE && !board.control(sq, BLACK)) {
 		if (board.castling & WHITE_OO) {
-			Bitboard mask = rook_blockers[sq][board.rook_pos[0]] | square_bits(SQ_F1);
-			if (mask & occs)
+			if (castle_blockers[sq][board.rook_pos[0]] & occs)
 				goto skip_white_oo;
 			for (Square s = Square(sq + 1); s <= SQ_G1; s++) {
 				if (board.control(s, BLACK))
@@ -410,8 +430,7 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 		}
 	skip_white_oo:
 		if (board.castling & WHITE_OOO) {
-			Bitboard mask = rook_blockers[sq][board.rook_pos[1]] | square_bits(SQ_D1);
-			if (mask & occs)
+			if (castle_blockers[sq][board.rook_pos[1]] & occs)
 				goto skip_white_ooo;
 			for (Square s = SQ_C1; s < sq; s++) {
 				if (board.control(s, BLACK))
@@ -422,8 +441,7 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 	skip_white_ooo:;
 	} else if (board.side == BLACK && !board.control(sq, WHITE)) {
 		if (board.castling & BLACK_OO) {
-			Bitboard mask = rook_blockers[sq][board.rook_pos[2]] | square_bits(SQ_F8);
-			if (mask & occs)
+			if (castle_blockers[sq][board.rook_pos[2]] & occs)
 				goto skip_black_oo;
 			for (Square s = Square(sq + 1); s <= SQ_G8; s++) {
 				if (board.control(s, WHITE))
@@ -433,8 +451,7 @@ void king_moves(const Board &board, pzstd::vector<Move> &moves) {
 		}
 	skip_black_oo:
 		if (board.castling & BLACK_OOO) {
-			Bitboard mask = rook_blockers[sq][board.rook_pos[3]] | square_bits(SQ_D8);
-			if (mask & occs)
+			if (castle_blockers[sq][board.rook_pos[3]] & occs)
 				goto skip_black_ooo;
 			for (Square s = SQ_C8; s < sq; s++) {
 				if (board.control(s, WHITE))

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -245,7 +245,7 @@ Value quiesce(ThreadInfo &ti, Value alpha, Value beta, int side, int depth, bool
 	// Sort captures and promotions
 	pzstd::vector<std::pair<Move, int>> scores;
 	for (Move &move : moves) {
-		if (ti.board.piece_boards[OPPOCC(ti.board.side)] & square_bits(move.dst())) {
+		if (ti.board.is_capture(move)) {
 			int score = 0;
 			score = MVV_LVA[ti.board.mailbox[move.dst()] & 7][ti.board.mailbox[move.src()] & 7];
 			scores.push_back({move, score});
@@ -581,8 +581,8 @@ Value negamax(ThreadInfo &ti, int depth, Value alpha = -VALUE_INFINITE, Value be
 	while ((move = mp.next()) != NullMove) {
 		if (move == ti.line[ply].excl || !board.is_legal(move))
 			continue;
-		
-		bool capt = (board.piece_boards[OPPOCC(board.side)] & square_bits(move.dst()));
+
+		bool capt = board.is_capture(move);
 		bool promo = (move.type() == PROMOTION);
 		
 		int extension = 0;
@@ -846,7 +846,7 @@ Value negamax(ThreadInfo &ti, int depth, Value alpha = -VALUE_INFINITE, Value be
 		else return 0;
 	}
 
-	bool best_iscapture = (board.piece_boards[OPPOCC(board.side)] & square_bits(best_move.dst()));
+	bool best_iscapture = board.is_capture(best_move);
 	bool best_ispromo = (best_move.type() == PROMOTION);
 	if (!excluded && !in_check && !(best_move != NullMove && (best_iscapture || best_ispromo))
 		&& !(flag == UPPER_BOUND && best >= cur_eval) && !(flag == LOWER_BOUND && best <= cur_eval)) {


### PR DESCRIPTION
DFRC Correctness Test
```
Elo   | -0.34 +- 7.27 (95%)
Conf  | 2.0+0.02s Threads=2 Hash=32MB
Games | N: 4040 W: 1023 L: 1027 D: 1990
Penta | [111, 487, 827, 485, 110]
```
https://ob.int0x80.ca/test/452/

Standard chess regression test
```
Elo   | 9.28 +- 5.96 (95%)
SPRT  | 8.0+0.08s Threads=2 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 3406 W: 846 L: 755 D: 1805
Penta | [12, 357, 869, 458, 7]
```
https://ob.int0x80.ca/test/461/

Bench: 4617857