### PR TITLE
Only do less LMR in the root

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -810,7 +810,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 		 * the search.
 		 */
 		Value score;
-		if (depth >= 2 && i >= 1 + 2 * pv) {
+		if (depth >= 2 && i >= 1 + 2 * root) {
 			// Case 1: Late moves in nodes
 
 			int r = reduction[i][depth];


### PR DESCRIPTION
```
Elo   | 3.70 +- 2.87 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 14932 W: 3527 L: 3368 D: 8037
Penta | [48, 1703, 3806, 1860, 49]
```
https://ob.int0x80.ca/test/625/

```
Elo   | 2.23 +- 2.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.79 (-2.25, 2.89) [0.00, 5.00]
Games | N: 21454 W: 4918 L: 4780 D: 11756
Penta | [22, 2469, 5604, 2613, 19]
```
https://ob.int0x80.ca/test/626/

Bench: 4182126