### PR TITLE
Lower SE margin

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -680,7 +680,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 			 * We can also extend more if the position without the move is *very* bad.
 			 */
 			ti.line[ply].excl = move;
-			Value singular_beta = tteval - 2 * depth;
+			Value singular_beta = tteval - 6 * depth / 4;
 			Value singular_score = negamax(pos, ti, (depth-1) / 2, singular_beta - 1, singular_beta, side, 0, cutnode, ply);
 			ti.line[ply].excl = NullMove; // Reset exclusion move
 


### PR DESCRIPTION
```
Elo   | 3.95 +- 2.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12500 W: 2853 L: 2711 D: 6936
Penta | [6, 1377, 3345, 1513, 9]
```
https://ob.int0x80.ca/test/664/

Bench: 4843290