### PR TITLE
Only do TT cutoffs if tt eval is below alpha in ALL nodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -431,7 +431,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 	Value tteval = -VALUE_INFINITE;
 	bool ttcapt = false;
 	if (tentry && is_valid_score(tentry->eval)) tteval = tt_to_score(tentry->eval, ply);
-	if (!pv && tentry && is_valid_score(tteval) && tentry->depth >= depth && ti.line[ply].excl == NullMove) {
+	if (!pv && tentry && is_valid_score(tteval) && tentry->depth >= depth && !excluded && (tteval <= alpha || cutnode)) {
 		// Check for cutoffs
 		if (tentry->bound() == EXACT) {
 			return tteval;


### PR DESCRIPTION
```
Elo   | 2.45 +- 1.99 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 27678 W: 6612 L: 6417 D: 14649
Penta | [23, 3099, 7394, 3306, 17]
```
https://ob.int0x80.ca/test/714/

Bench: 4171649