### PR TITLE
Check for time limit more often

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -200,8 +200,8 @@ Value quiesce(Position &pos, ThreadInfo &ti, Value alpha, Value beta, int side, 
 
 	if (ti.is_main) {
 		auto cur_nodes = nodes[ti.id].get();
-		if (!(cur_nodes & 4095)) {
-			// The time check is relatively expensive and thus only performed every 4096 nodes
+		if (!(cur_nodes & 1023)) {
+			// The time check is relatively expensive and thus only performed every 1024 nodes
 			auto time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
 			if (time > mxtime) {
 				stop_search = true;
@@ -378,8 +378,8 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 
 	if (ti.is_main) {
 		auto cur_nodes = nodes[ti.id].get();
-		if (!(cur_nodes & 4095)) {
-			// The time check is relatively expensive and thus only performed every 4096 nodes
+		if (!(cur_nodes & 1023)) {
+			// The time check is relatively expensive and thus only performed every 1024 nodes
 			auto time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
 			if (time > mxtime) {
 				stop_search = true;


### PR DESCRIPTION
```
Elo   | 0.04 +- 2.66 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 27650 W: 8122 L: 8119 D: 11409
Penta | [648, 3221, 6096, 3200, 660]
```
https://ob.int0x80.ca/test/745/

Bench: 4461356