### PR TITLE
Lower min SE depth except in ttpv nodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -674,7 +674,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 		
 		int extension = 0;
 
-		if (!root && !excluded && depth >= 8 && tentry && is_valid_score(tteval) && move == tentry->best_move && tentry->depth >= depth - 3 && tentry->bound() != UPPER_BOUND) {
+		if (!root && !excluded && depth >= 7 + ttpv && tentry && is_valid_score(tteval) && move == tentry->best_move && tentry->depth >= depth - 3 && tentry->bound() != UPPER_BOUND) {
 			/**
 			 * Singular extensions
 			 * 


### PR DESCRIPTION
```
Elo   | 3.41 +- 2.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 5.00]
Games | N: 17510 W: 4221 L: 4049 D: 9240
Penta | [63, 2024, 4429, 2156, 83]
```
https://ob.int0x80.ca/test/792/

```
Elo   | 3.14 +- 5.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.67 (-2.25, 2.89) [0.00, 5.00]
Games | N: 4202 W: 1004 L: 966 D: 2232
Penta | [4, 485, 1084, 525, 3]
```
https://ob.int0x80.ca/test/793/

Bench: 4104634