### PR TITLE
Do less LMR in high corrplexity positions

### DIFF
--- a/engine/params.hpp
+++ b/engine/params.hpp
@@ -67,6 +67,7 @@ TUNE(lmr_killer, 835, 0, 2048, 128);
 TUNE(lmr_hist, 12, 1, 16, 2);
 TUNE(lmr_ttcapt, 914, 0, 2048, 128);
 TUNE(lmr_ttpv_alpha, -34, -1024, 1024, 256);
+TUNE(lmr_corr, 400, 0, 1024, 128);
 TUNE(dodeeper_margin, 109, 20, 200, 10);
 TUNE(doshallower_margin, -3, -64, 64, 8);
 TUNE(hist_large_margin, 96, 0, 256, 16);

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -482,10 +482,12 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 	Value cur_eval = 0;
 	Value raw_eval = 0;
 	Value tt_corr_eval = 0;
+	Value corr_val = 0;
 	if (!in_check) {
 		cur_eval = tentry && is_valid_score(tentry->s_eval) ? tentry->s_eval : eval(pos, ti.am) * side;
 		raw_eval = cur_eval;
 		if (!excluded) ti.thread_corrhist.apply_correction(pos, &ti.line[ply], ply, cur_eval);
+		corr_val = abs(cur_eval - raw_eval);
 		tt_corr_eval = cur_eval;
 		if (tentry && is_valid_score(tteval) && abs(tteval) < VALUE_WIN && tentry->bound() != (tteval > cur_eval ? UPPER_BOUND : LOWER_BOUND))
 			tt_corr_eval = tteval;
@@ -846,6 +848,8 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 			
 			if (ttpv && is_valid_score(tteval) && tteval <= alpha)
 				r += lmr_ttpv_alpha();
+
+			r -= corr_val * lmr_corr() / 128;
 
 			if (!capt && !promo)
 				r -= hist / 10;


### PR DESCRIPTION
```
Elo   | 2.39 +- 1.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 5.00]
Games | N: 34788 W: 8456 L: 8217 D: 18115
Penta | [160, 4093, 8643, 4344, 154]
```
https://ob.int0x80.ca/test/791/

```
Elo   | 2.72 +- 2.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.36 (-2.25, 2.89) [0.00, 5.00]
Games | N: 19174 W: 4551 L: 4401 D: 10222
Penta | [19, 2219, 4960, 2371, 18]
```
https://ob.int0x80.ca/test/798/

Bench: 4655378