### PR TITLE
Adjust RFP margin based on corrplexity

### DIFF
--- a/engine/params.hpp
+++ b/engine/params.hpp
@@ -41,6 +41,7 @@ TUNE(rfp_threshold, 63, 20, 110, 10);
 TUNE(rfp_improving, 31, 10, 50, 8);
 TUNE(rfp_quad, 5, 1, 8, 1);
 TUNE(rfp_cutnode, 15, 5, 30, 5);
+TUNE(rfp_corr, 100, 20, 250, 20);
 TUNE(nmp_margin, 214, 50, 400, 25);
 TUNE(nmp_depth, 13, 0, 40, 5);
 TUNE(razor_margin, 227, 150, 400, 20);

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -513,7 +513,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 		 * 
 		 * We need to make sure that we aren't in check (since we might get mated)
 		 */
-		int margin = (rfp_threshold() - improving * rfp_improving()) * depth + rfp_quad() * depth * depth - rfp_cutnode() * cutnode;
+		int margin = (rfp_threshold() - improving * rfp_improving()) * depth + rfp_quad() * depth * depth - rfp_cutnode() * cutnode + corr_val * rfp_corr() / 1024;
 		if (tt_corr_eval >= beta + margin)
 			return ((int)tt_corr_eval + beta) / 2;
 	}


### PR DESCRIPTION
Didn't pass but it doesn't seem to be a massive negative Elo change; we will let SPSA take care of it.

```
Elo   | 3.51 +- 6.36 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.53 (-2.25, 2.89) [0.00, 5.00]
Games | N: 2770 W: 678 L: 650 D: 1442
Penta | [1, 311, 738, 329, 6]
```
https://ob.int0x80.ca/test/794/

Bench: 4558294