### PR TITLE
Add Syzygy DTZ probing at root

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -18,6 +18,8 @@ std::atomic<uint64_t> nodecnt[64][64] = {{}};
 NodeCounter nodes[MAX_THREADS];
 std::atomic<uint64_t> tbhits = 0;
 
+std::unordered_set<uint16_t> tb_moves;
+
 uint64_t perft(Position &pos, int depth) {
 	if (depth == 0)
 		return 1;
@@ -668,6 +670,9 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 	while ((move = mp.next()) != NullMove) {
 		if (move == ti.line[ply].excl || !pos.is_legal(move))
 			continue;
+
+		if (root && !tb_moves.empty() && !tb_moves.count(move.data))
+			continue; // If the current move isn't included in the viable TB moves, skip
 
 		bool capt = pos.is_capture(move);
 		bool promo = (move.type() == PROMOTION);

--- a/engine/search.hpp
+++ b/engine/search.hpp
@@ -67,6 +67,7 @@ struct alignas(64) NodeCounter {
 };
 
 extern NodeCounter nodes[MAX_THREADS];
+extern std::unordered_set<uint16_t> tb_moves;
 
 struct ThreadInfo {
 	Position pos;

--- a/engine/tb.cpp
+++ b/engine/tb.cpp
@@ -65,11 +65,11 @@ std::unordered_set<uint16_t> TBManager::probe_moves(Position &pos, bool rep) {
 			auto move = moves.moves[i].move;
 			
 			Move pz_move = Move(PYRRHIC_MOVE_FROM(move), PYRRHIC_MOVE_TO(move));
-			if (TB_RESULT_IS_ENPASS(move)) pz_move.data |= (2 << 14);
-			else if (TB_RESULT_IS_QPROMO(move)) pz_move.data |= (1 << 14) | ((QUEEN - KNIGHT) << 12);
-			else if (TB_RESULT_IS_RPROMO(move)) pz_move.data |= (1 << 14) | ((ROOK - KNIGHT) << 12);
-			else if (TB_RESULT_IS_BPROMO(move)) pz_move.data |= (1 << 14) | ((BISHOP - KNIGHT) << 12);
-			else if (TB_RESULT_IS_NPROMO(move)) pz_move.data |= (1 << 14) | ((KNIGHT - KNIGHT) << 12);
+			if (PYRRHIC_MOVE_IS_ENPASS(move)) pz_move.data |= (2 << 14);
+			else if (PYRRHIC_MOVE_IS_QPROMO(move)) pz_move.data |= (1 << 14) | ((QUEEN - KNIGHT) << 12);
+			else if (PYRRHIC_MOVE_IS_RPROMO(move)) pz_move.data |= (1 << 14) | ((ROOK - KNIGHT) << 12);
+			else if (PYRRHIC_MOVE_IS_BPROMO(move)) pz_move.data |= (1 << 14) | ((BISHOP - KNIGHT) << 12);
+			else if (PYRRHIC_MOVE_IS_NPROMO(move)) pz_move.data |= (1 << 14) | ((KNIGHT - KNIGHT) << 12);
 
 			viable_moves.insert(pz_move.data);
 		}

--- a/engine/tb.cpp
+++ b/engine/tb.cpp
@@ -47,7 +47,6 @@ std::unordered_set<uint16_t> TBManager::probe_moves(Position &pos, bool rep) {
 		pos.piece_boards[KNIGHT], pos.piece_boards[PAWN], pos.halfmove, ep_sq, turn, rep, &moves);
 	
 	if (res == 0) {
-		std::cerr << "Câlisse de tabarnak, tu te fous de moi ou quoi ?" << std::endl;
 		return viable_moves;
 	}
 

--- a/engine/tb.cpp
+++ b/engine/tb.cpp
@@ -1,7 +1,5 @@
 #include "tb.hpp"
 
-#include <cassert>
-
 std::optional<int> TBManager::probe_pos(Position &pos) {
 	if (!initialized || pos.halfmove != 0 || pos.castling) {
 		return std::nullopt;

--- a/engine/tb.cpp
+++ b/engine/tb.cpp
@@ -31,7 +31,7 @@ std::optional<int> TBManager::probe_pos(Position &pos) {
 
 std::unordered_set<uint16_t> TBManager::probe_moves(Position &pos, bool rep) {
 	std::unordered_set<uint16_t> viable_moves;
-	if (!initialized || pos.halfmove != 0 || pos.castling) {
+	if (!initialized || pos.castling) {
 		return viable_moves;
 	}
 
@@ -65,25 +65,12 @@ std::unordered_set<uint16_t> TBManager::probe_moves(Position &pos, bool rep) {
 			auto move = moves.moves[i].move;
 			
 			Move pz_move = Move(PYRRHIC_MOVE_FROM(move), PYRRHIC_MOVE_TO(move));
-			if (TB_RESULT_IS_ENPASS(move)) {
-				pz_move.data |= (2 << 14); // set en passant flag
-				assert(pz_move.type() == EN_PASSANT);
-			}
-			if (TB_RESULT_IS_QPROMO(move)) {
-				pz_move.data |= (1 << 14) | ((QUEEN - KNIGHT) << 12);
-				assert(pz_move.type() == PROMOTION && pz_move.promotion() == QUEEN);
-			} else if (TB_RESULT_IS_RPROMO(move)) {
-				pz_move.data |= (1 << 14) | ((ROOK - KNIGHT) << 12);
-				assert(pz_move.type() == PROMOTION && pz_move.promotion() == ROOK);
-			} else if (TB_RESULT_IS_BPROMO(move)) {
-				pz_move.data |= (1 << 14) | ((BISHOP - KNIGHT) << 12);
-				assert(pz_move.type() == PROMOTION && pz_move.promotion() == BISHOP);
-			} else if (TB_RESULT_IS_NPROMO(move)) {
-				pz_move.data |= (1 << 14) | ((KNIGHT - KNIGHT) << 12);
-				assert(pz_move.type() == PROMOTION && pz_move.promotion() == KNIGHT);
-			}
+			if (TB_RESULT_IS_ENPASS(move)) pz_move.data |= (2 << 14);
+			else if (TB_RESULT_IS_QPROMO(move)) pz_move.data |= (1 << 14) | ((QUEEN - KNIGHT) << 12);
+			else if (TB_RESULT_IS_RPROMO(move)) pz_move.data |= (1 << 14) | ((ROOK - KNIGHT) << 12);
+			else if (TB_RESULT_IS_BPROMO(move)) pz_move.data |= (1 << 14) | ((BISHOP - KNIGHT) << 12);
+			else if (TB_RESULT_IS_NPROMO(move)) pz_move.data |= (1 << 14) | ((KNIGHT - KNIGHT) << 12);
 
-			assert(pos.is_legal(pz_move));
 			viable_moves.insert(pz_move.data);
 		}
 	}

--- a/engine/tb.cpp
+++ b/engine/tb.cpp
@@ -1,5 +1,7 @@
 #include "tb.hpp"
 
+#include <cassert>
+
 std::optional<int> TBManager::probe_pos(Position &pos) {
 	if (!initialized || pos.halfmove != 0 || pos.castling) {
 		return std::nullopt;
@@ -25,6 +27,68 @@ std::optional<int> TBManager::probe_pos(Position &pos) {
 	if (res == TB_WIN) return 1;
 	if (res == TB_LOSS) return -1;
 	return 0; // draws, cursed wins, and blessed losses are all treated as draws
+}
+
+std::unordered_set<uint16_t> TBManager::probe_moves(Position &pos, bool rep) {
+	std::unordered_set<uint16_t> viable_moves;
+	if (!initialized || pos.halfmove != 0 || pos.castling) {
+		return viable_moves;
+	}
+
+	int npieces = _mm_popcnt_u64(pos.piece_boards[OCC(WHITE)] | pos.piece_boards[OCC(BLACK)]);
+	if (npieces > TB_LARGEST || npieces > max_pieces) {
+		return viable_moves;
+	}
+
+	auto ep_sq = pos.ep_square != SQ_NONE ? pos.ep_square : 0;
+	auto turn = pos.side == WHITE ? PYRRHIC_WHITE : PYRRHIC_BLACK;
+
+	TbRootMoves moves = {};
+	int res = tb_probe_root_dtz(pos.piece_boards[OCC(WHITE)], pos.piece_boards[OCC(BLACK)],
+		pos.piece_boards[KING], pos.piece_boards[QUEEN], pos.piece_boards[ROOK], pos.piece_boards[BISHOP],
+		pos.piece_boards[KNIGHT], pos.piece_boards[PAWN], pos.halfmove, ep_sq, turn, rep, &moves);
+	
+	if (res == 0) {
+		std::cerr << "Câlisse de tabarnak, tu te fous de moi ou quoi ?" << std::endl;
+		return viable_moves;
+	}
+
+	int optimal_score = -2147483647;
+	for (int i = 0; i < moves.size; i++) {
+		int score = moves.moves[i].tbRank;
+		optimal_score = std::max(optimal_score, score);
+	}
+
+	for (int i = 0; i < moves.size; i++) {
+		int score = moves.moves[i].tbRank;
+		if (score == optimal_score) {
+			auto move = moves.moves[i].move;
+			
+			Move pz_move = Move(PYRRHIC_MOVE_FROM(move), PYRRHIC_MOVE_TO(move));
+			if (TB_RESULT_IS_ENPASS(move)) {
+				pz_move.data |= (2 << 14); // set en passant flag
+				assert(pz_move.type() == EN_PASSANT);
+			}
+			if (TB_RESULT_IS_QPROMO(move)) {
+				pz_move.data |= (1 << 14) | ((QUEEN - KNIGHT) << 12);
+				assert(pz_move.type() == PROMOTION && pz_move.promotion() == QUEEN);
+			} else if (TB_RESULT_IS_RPROMO(move)) {
+				pz_move.data |= (1 << 14) | ((ROOK - KNIGHT) << 12);
+				assert(pz_move.type() == PROMOTION && pz_move.promotion() == ROOK);
+			} else if (TB_RESULT_IS_BPROMO(move)) {
+				pz_move.data |= (1 << 14) | ((BISHOP - KNIGHT) << 12);
+				assert(pz_move.type() == PROMOTION && pz_move.promotion() == BISHOP);
+			} else if (TB_RESULT_IS_NPROMO(move)) {
+				pz_move.data |= (1 << 14) | ((KNIGHT - KNIGHT) << 12);
+				assert(pz_move.type() == PROMOTION && pz_move.promotion() == KNIGHT);
+			}
+
+			assert(pos.is_legal(pz_move));
+			viable_moves.insert(pz_move.data);
+		}
+	}
+
+	return viable_moves;
 }
 
 TBManager tbman;

--- a/engine/tb.hpp
+++ b/engine/tb.hpp
@@ -46,10 +46,8 @@ struct TBManager {
 	/**
 	 * Probes the tablebase for a given position and returns the viable moves
 	 * (i.e. the ones that are not different than the optimal result).
-	 * 
-	 * Not yet implemented.
 	 */
-	// std::unordered_set<Move> probe_moves(Position &pos);
+	std::unordered_set<uint16_t> probe_moves(Position &pos, bool rep = false);
 };
 
 extern TBManager tbman;

--- a/engine/threads.cpp
+++ b/engine/threads.cpp
@@ -1,5 +1,7 @@
 #include "threads.hpp"
 
+#include <cassert>
+
 void Pool::resize(size_t num) {
 	if (num == num_threads)
 		return;
@@ -57,6 +59,24 @@ void Pool::search(Position &pos, RepetitionHandler &rp, int64_t time, int depth,
 		nodes[t] = 0;
 		ti.id = t;
 		ti.is_main = (t == 0);
+	}
+
+	bool rep = false;
+	assert(rp.hash_hist.empty() || rp.hash_hist[rp.hash_hist.size() - 1] == pos.zobrist);
+	for (int i = rp.hash_hist.size() - 2; i >= 0; i--) {
+		if (rp.hash_hist[i] == pos.zobrist) {
+			rep = true;
+			break;
+		}
+	}
+	tb_moves = tbman.probe_moves(pos, rep);
+
+	if (!tb_moves.empty()) {
+		std::cerr << "Tablebase hit! Viable moves: ";
+		for (auto move : tb_moves) {
+			std::cerr << Move(move).to_string() << " ";
+		}
+		std::cerr << std::endl;
 	}
 
 	start_barrier->arrive_and_wait();

--- a/engine/threads.cpp
+++ b/engine/threads.cpp
@@ -1,7 +1,5 @@
 #include "threads.hpp"
 
-#include <cassert>
-
 void Pool::resize(size_t num) {
 	if (num == num_threads)
 		return;
@@ -62,22 +60,13 @@ void Pool::search(Position &pos, RepetitionHandler &rp, int64_t time, int depth,
 	}
 
 	bool rep = false;
-	assert(rp.hash_hist.empty() || rp.hash_hist[rp.hash_hist.size() - 1] == pos.zobrist);
 	for (int i = rp.hash_hist.size() - 2; i >= 0; i--) {
-		if (rp.hash_hist[i] == pos.zobrist) {
+		if (rp.hash_hist[i] == pos.zobrist_without_ep()) {
 			rep = true;
 			break;
 		}
 	}
 	tb_moves = tbman.probe_moves(pos, rep);
-
-	if (!tb_moves.empty()) {
-		std::cerr << "Tablebase hit! Viable moves: ";
-		for (auto move : tb_moves) {
-			std::cerr << Move(move).to_string() << " ";
-		}
-		std::cerr << std::endl;
-	}
 
 	start_barrier->arrive_and_wait();
 	ready_barrier->arrive_and_wait();


### PR DESCRIPTION
Probing DTZ tablebases at root prevents the engine from making silly mistakes, as can be observed in [this game](https://ctv.yoshie2000.de/?provider=ccc&event=475&game=191279).

Bench: 4475226