### PR TITLE
Add MADV_HUGEPAGE

### DIFF
--- a/engine/mem.hpp
+++ b/engine/mem.hpp
@@ -22,11 +22,9 @@ static void *large_alloc(size_t size) {
 	if (ptr == MAP_FAILED) {
 		std::__throw_runtime_error(strerror(errno));
 	}
-#ifdef MADV_COLLAPSE
-	madvise(ptr, size, MADV_COLLAPSE);
-#else
+
 	madvise(ptr, size, MADV_HUGEPAGE);
-#endif
+
 	return ptr;
 #endif
 }

--- a/engine/mem.hpp
+++ b/engine/mem.hpp
@@ -22,6 +22,7 @@ static void *large_alloc(size_t size) {
 	if (ptr == MAP_FAILED) {
 		std::__throw_runtime_error(strerror(errno));
 	}
+	madvise(ptr, size, MADV_COLLAPSE);
 	return ptr;
 #endif
 }

--- a/engine/mem.hpp
+++ b/engine/mem.hpp
@@ -22,7 +22,11 @@ static void *large_alloc(size_t size) {
 	if (ptr == MAP_FAILED) {
 		std::__throw_runtime_error(strerror(errno));
 	}
+#ifdef MADV_COLLAPSE
 	madvise(ptr, size, MADV_COLLAPSE);
+#else
+	madvise(ptr, size, MADV_HUGEPAGE);
+#endif
 	return ptr;
 #endif
 }


### PR DESCRIPTION
Used to be MADV_COLLAPSE but that lost

```
Elo   | 6.20 +- 4.18 (95%)
SPRT  | 2.0+0.02s Threads=4 Hash=2048MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8074 W: 2134 L: 1990 D: 3950
Penta | [52, 934, 1937, 1046, 68]
```
https://ob.int0x80.ca/test/819/

Bench: 4921015