### PR TITLE
Add draw detection to qsearch

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -222,6 +222,11 @@ Value quiesce(Position &pos, ThreadInfo &ti, Value alpha, Value beta, int side, 
 
 	RepetitionHandler &rp = ti.rp;
 
+	// Threefold or 50 move rule
+	if (rp.threefold(ply, pos.zobrist_without_ep()) || pos.halfmove >= 100 || pos.insufficient_material()) {
+		return 0;
+	}
+
 	if (ply >= MAX_PLY)
 		return eval(pos, ti.am) * side; // Just in case
 


### PR DESCRIPTION
```
Elo   | 2.12 +- 3.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 10658 W: 2584 L: 2519 D: 5555
Penta | [37, 1233, 2731, 1284, 44]
```
https://ob.int0x80.ca/test/832/

Bench: 4417680