### PR TITLE
Fix an issue in DFRC fen loading

### DIFF
--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -165,7 +165,8 @@ void Position::load_fen(std::string fen) {
 		if (fen[inputIdx] == 'K') {
 			castling |= WHITE_OO;
 			inputIdx++;
-			if (dfrc_uci) {
+			if (dfrc_uci || mailbox[SQ_H1] != WHITE_ROOK) {
+				dfrc_uci = true;
 				Square king_square = make_square(File(king_file - 'A'), RANK_1);
 				Bitboard mask = ~(square_bits(king_square) - 1);
 				rook_pos[0] = Square(arch::tzcnt(rooks & mask & piece_boards[OCC(WHITE)]));
@@ -182,7 +183,8 @@ void Position::load_fen(std::string fen) {
 		if (fen[inputIdx] == 'Q') {
 			castling |= WHITE_OOO;
 			inputIdx++;
-			if (dfrc_uci) {
+			if (dfrc_uci || mailbox[SQ_A1] != WHITE_ROOK) {
+				dfrc_uci = true;
 				Square king_square = make_square(File(king_file - 'A'), RANK_1);
 				Bitboard mask = (square_bits(king_square) - 1);
 				rook_pos[1] = Square(arch::tzcnt(rooks & mask & piece_boards[OCC(WHITE)]));
@@ -200,7 +202,8 @@ void Position::load_fen(std::string fen) {
 		if (fen[inputIdx] == 'k') {
 			castling |= BLACK_OO;
 			inputIdx++;
-			if (dfrc_uci) {
+			if (dfrc_uci || mailbox[SQ_H8] != BLACK_ROOK) {
+				dfrc_uci = true;
 				Square king_square = make_square(File(king_file - 'a'), RANK_8);
 				Bitboard mask = ~(square_bits(king_square) - 1);
 				rook_pos[2] = Square(arch::tzcnt(rooks & mask & piece_boards[OCC(BLACK)]));
@@ -217,7 +220,8 @@ void Position::load_fen(std::string fen) {
 		if (fen[inputIdx] == 'q') {
 			castling |= BLACK_OOO;
 			inputIdx++;
-			if (dfrc_uci) {
+			if (dfrc_uci || mailbox[SQ_A8] != BLACK_ROOK) {
+				dfrc_uci = true;
 				Square king_square = make_square(File(king_file - 'a'), RANK_8);
 				Bitboard mask = (square_bits(king_square) - 1);
 				rook_pos[3] = Square(63 - arch::lzcnt(rooks & mask & piece_boards[OCC(BLACK)]));


### PR DESCRIPTION
Fixes an issue where DFRC fens are interpreted as standard when `UCI_Chess960` is not necessarily specified (i.e. in datagen environments). Otherwise, when `UCI_Chess960` is set, this should have no effect.

```
Elo   | -0.00 +- 0.00 (95%)
SPRT  | N=5000 Threads=1 Hash=32MB
LLR   | 0.55 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 2696 W: 1084 L: 1084 D: 528
Penta | [0, 0, 1348, 0, 0]
```
https://ob.int0x80.ca/test/888/

Bench: 4482993