### PR TITLE
Add post-lmr conthist updates

### DIFF
--- a/engine/history.cpp
+++ b/engine/history.cpp
@@ -31,6 +31,11 @@ int History::get_capthist(Position &pos, Move move) {
 void History::update_history(Position &pos, Move &move, int ply, SSEntry *line, Value bonus) {
 	int cbonus = std::clamp(bonus, (Value)(-MAX_HISTORY), MAX_HISTORY);
 	history[pos.side][move.src()][move.dst()][pos.control(move.src(), !pos.side)][pos.control(move.dst(), !pos.side)] += cbonus - history[pos.side][move.src()][move.dst()][pos.control(move.src(), !pos.side)][pos.control(move.dst(), !pos.side)] * abs(bonus) / MAX_HISTORY;
+	update_conthist(pos, move, ply, line, bonus);
+}
+
+void History::update_conthist(Position &pos, Move move, int ply, SSEntry *line, Value bonus) {
+	int cbonus = std::clamp(bonus, (Value)(-MAX_HISTORY), MAX_HISTORY);
 	int conthist = get_conthist(pos, move, ply, line);
 	if (ply >= 1 && (line - 1)->cont_hist)
 		(line - 1)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;

--- a/engine/history.hpp
+++ b/engine/history.hpp
@@ -54,6 +54,7 @@ struct History {
 	int get_capthist(Position &pos, Move move);
 
 	void update_history(Position &pos, Move &move, int ply, SSEntry *line, Value bonus);
+	void update_conthist(Position &pos, Move move, int ply, SSEntry *line, Value bonus);
 	void update_capthist(Position &pos, Move move, Value bonus);
 };
 

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -140,6 +140,13 @@ Value tt_to_score(Value score, int ply) {
 }
 
 /**
+ * Get the history score bonus for a given depth
+ */
+Value hist_bonus(int depth) {
+	return std::min(1896, hist_quad() * depth * depth + hist_lin() * depth - hist_const());
+}
+
+/**
  * Get the usage of the transposition table
  *
  * Used for UCI output. This function samples the first 1024 entries of the TTable
@@ -907,6 +914,11 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 
 				if (searched_depth < newdepth) {
 					score = -negamax(pos_after, ti, newdepth, -alpha - 1, -alpha, -side, 0, !cutnode, ply + 1);
+
+					if (!capt && !promo && (score <= alpha || score >= beta) && !stop_search) {
+						const int bonus = score >= beta ? hist_bonus(newdepth) : -hist_bonus(newdepth);
+						ti.thread_hist.update_conthist(pos, move, ply, &ti.line[ply], bonus);
+					}
 				}
 			}
 		} else if (!pv || i > 0) {
@@ -973,7 +985,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 				ti.line[ply].killer = move; // Update killer move
 			}
 			int hist_depth = depth + (score >= beta + hist_large_margin());
-			const int bonus = std::min(1896, hist_quad() * hist_depth * hist_depth + hist_lin() * hist_depth - hist_const());
+			const int bonus = hist_bonus(hist_depth);
 			if (!capt) { // Not a capture
 				ti.thread_hist.update_history(pos, move, ply, &ti.line[ply], bonus);
 				for (auto &qmove : quiets) {


### PR DESCRIPTION
Speculative merge

```
Elo   | 0.67 +- 0.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -1.27 (-2.25, 2.89) [0.00, 3.00]
Games | N: 230460 W: 56654 L: 56207 D: 117599
Penta | [980, 27855, 57180, 28168, 1047]
```
https://ob.int0x80.ca/test/895/

Bench: 4042341