### PR TITLE
Only do NMP in expected cutnodes

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -580,7 +580,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 	// Null-move pruning
 	int npieces = arch::popcnt(pos.piece_boards[OCC(WHITE)] | pos.piece_boards[OCC(BLACK)]);
 	int npawns_and_kings = arch::popcnt(pos.piece_boards[PAWN] | pos.piece_boards[KING]);
-	if (!pv && !in_check && !ti.nmp_disable && npieces != npawns_and_kings && cur_eval >= beta + nmp_margin() - nmp_depth() * depth && depth >= 2 && !excluded) { // Avoid NMP in pawn endgames
+	if (cutnode && !in_check && !ti.nmp_disable && npieces != npawns_and_kings && cur_eval >= beta + nmp_margin() - nmp_depth() * depth && depth >= 2 && !excluded) { // Avoid NMP in pawn endgames
 		/**
 		 * This works off the *null-move observation*.
 		 *


### PR DESCRIPTION
```
Elo   | 3.99 +- 3.65 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.95 (-2.25, 2.89) [0.00, 5.00]
Games | N: 8280 W: 2006 L: 1911 D: 4363
Penta | [5, 916, 2203, 1011, 5]
```
https://ob.int0x80.ca/test/904/

Bench: 4334960