### PR TITLE
Remove line bounds checks

### DIFF
--- a/engine/history.cpp
+++ b/engine/history.cpp
@@ -21,15 +21,15 @@
 
 int History::get_conthist(Position &pos, Move move, int ply, SSEntry *line) {
 	int score = 0;
-	if (ply >= 1 && (line - 1)->cont_hist)
+	if ((line - 1)->cont_hist)
 		score += (line - 1)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()];
-	if (ply >= 2 && (line - 2)->cont_hist)
+	if ((line - 2)->cont_hist)
 		score += (line - 2)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()];
-	if (ply >= 3 && (line - 3)->cont_hist)
+	if ((line - 3)->cont_hist)
 		score += (line - 3)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()];
-	if (ply >= 4 && (line - 4)->cont_hist)
+	if ((line - 4)->cont_hist)
 		score += (line - 4)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()];
-	if (ply >= 6 && (line - 6)->cont_hist)
+	if ((line - 6)->cont_hist)
 		score += (line - 6)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()];
 	return score;
 }
@@ -55,15 +55,15 @@ void History::update_history(Position &pos, Move &move, int ply, SSEntry *line, 
 void History::update_conthist(Position &pos, Move move, int ply, SSEntry *line, Value bonus) {
 	int cbonus = std::clamp(bonus, (Value)(-MAX_HISTORY), MAX_HISTORY);
 	int conthist = get_conthist(pos, move, ply, line);
-	if (ply >= 1 && (line - 1)->cont_hist)
+	if ((line - 1)->cont_hist)
 		(line - 1)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
-	if (ply >= 2 && (line - 2)->cont_hist)
+	if ((line - 2)->cont_hist)
 		(line - 2)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
-	if (ply >= 3 && (line - 3)->cont_hist)
+	if ((line - 3)->cont_hist)
 		(line - 3)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
-	if (ply >= 4 && (line - 4)->cont_hist)
+	if ((line - 4)->cont_hist)
 		(line - 4)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
-	if (ply >= 6 && (line - 6)->cont_hist)
+	if ((line - 6)->cont_hist)
 		(line - 6)->cont_hist->hist[pos.side][pos.mailbox[move.src()] & 7][move.dst()] += cbonus - conthist * abs(bonus) / MAX_HISTORY;
 }
 


### PR DESCRIPTION
Remove checks like `if (ply >= 2)` before accessing SSEntry arrays

```
Avg: +0.6077% +/- +0.2225%, LLR: +3.31 (-2.25, 2.89)
```

Bench: 4334960