### PR TITLE
Do not do base LMR on i==1

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -68,12 +68,9 @@ uint64_t perft(Position &pos, int depth) {
 uint16_t reduction[250][MAX_PLY+8];
 
 __attribute__((constructor)) void init_lmr() {
-	for (int i = 0; i < 250; i++) {
-		for (int d = 0; d < MAX_PLY; d++) {
-			if (d <= 1 || i <= 1)
-				reduction[i][d] = 1024;
-			else
-				reduction[i][d] = (lmr_a() / 100.0 + log(i) * log(d) / (lmr_b() / 100.0)) * 1024;
+	for (int i = 1; i < 250; i++) {
+		for (int d = 1; d <= MAX_PLY; d++) {
+			reduction[i][d] = (lmr_a() / 100.0 + log(i) * log(d) / (lmr_b() / 100.0)) * 1024;
 		}
 	}
 }


### PR DESCRIPTION
```
Elo   | 1.20 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 14744 W: 3647 L: 3596 D: 7501
Penta | [72, 1730, 3707, 1801, 62]
```
https://ob.int0x80.ca/test/928/

Bench: 3294322