### PR TITLE
Do less triext if the move is a capture

### DIFF
--- a/engine/params.hpp
+++ b/engine/params.hpp
@@ -70,7 +70,7 @@ TUNE(dext_capt, 10, -100, 100, 10);
 TUNE(dext_pv, 35, -100, 100, 10);
 TUNE(dext_improving, 7, -50, 50, 10);
 TUNE(text_base, 118, 50, 200, 10);
-TUNE(text_capt, -61, -200, 200, 20);
+TUNE(text_capt, 50, 0, 200, 10);
 TUNE(fp_const, 297, 100, 500, 30);
 TUNE(fp_depth, 72, 20, 200, 10);
 TUNE(fp_hist, 32, 10, 64, 5);


### PR DESCRIPTION
Passed LTC nonreg:
```
Elo   | 5.53 +- 4.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 5092 W: 1246 L: 1165 D: 2681
Penta | [4, 549, 1360, 628, 5]
```
https://ob.int0x80.ca/test/930/

Bench: 2904242