### PR TITLE
Remove complexity TM

### DIFF
--- a/engine/params.hpp
+++ b/engine/params.hpp
@@ -113,9 +113,6 @@ TUNE(lmr_a, 99, 20, 200, 10);
 TUNE(lmr_b, 260, 100, 400, 20);
 
 TUNE(tm_soft, 53, 10, 90, 8);
-TUNE(cmplx_div, 192, 100, 400, 40);
-TUNE(cmplx_base, 64, 20, 120, 10);
-TUNE(cmplx_mul, 88, 40, 160, 10);
 TUNE(bm_base, 180, 80, 250, 15);
 TUNE(bm_mul, 20, 10, 80, 10);
 TUNE(node_base, 134, 100, 200, 10);

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -1176,14 +1176,6 @@ void iterativedeepening(Position &pos, ThreadInfo &ti, int depth) {
 
 			double soft = tm_soft() / 100.0;
 			if (d >= 6) {
-				// if (!best_iscapt && !best_ispromo && !in_check) {
-				// 	// adjust soft limit based on complexity
-				// 	Value complexity = abs(eval - static_eval);
-				// 	double factor = std::clamp(complexity / ((double)cmplx_div()), 0.0, 1.0);
-				// 	// higher complexity = spend more time, lower complexity = spend less time
-				// 	soft *= (cmplx_base() / 100.0) + (cmplx_mul() / 100.0) * factor;
-				// }
-
 				double bm_stability = bm_base() / 100.0 - bm_mul() / 100.0 * consec_move;
 				bm_stability = std::clamp(bm_stability, 0.8, 1.8);
 				soft *= bm_stability;

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -1176,13 +1176,13 @@ void iterativedeepening(Position &pos, ThreadInfo &ti, int depth) {
 
 			double soft = tm_soft() / 100.0;
 			if (d >= 6) {
-				if (!best_iscapt && !best_ispromo && !in_check) {
-					// adjust soft limit based on complexity
-					Value complexity = abs(eval - static_eval);
-					double factor = std::clamp(complexity / ((double)cmplx_div()), 0.0, 1.0);
-					// higher complexity = spend more time, lower complexity = spend less time
-					soft *= (cmplx_base() / 100.0) + (cmplx_mul() / 100.0) * factor;
-				}
+				// if (!best_iscapt && !best_ispromo && !in_check) {
+				// 	// adjust soft limit based on complexity
+				// 	Value complexity = abs(eval - static_eval);
+				// 	double factor = std::clamp(complexity / ((double)cmplx_div()), 0.0, 1.0);
+				// 	// higher complexity = spend more time, lower complexity = spend less time
+				// 	soft *= (cmplx_base() / 100.0) + (cmplx_mul() / 100.0) * factor;
+				// }
 
 				double bm_stability = bm_base() / 100.0 - bm_mul() / 100.0 * consec_move;
 				bm_stability = std::clamp(bm_stability, 0.8, 1.8);


### PR DESCRIPTION
Passed STC nonreg
```
Elo   | 3.29 +- 3.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7814 W: 1959 L: 1885 D: 3970
Penta | [26, 871, 2047, 929, 34]
```
https://ob.int0x80.ca/test/934/

Passed LTC nonreg
```
Elo   | 0.74 +- 3.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 1.26 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 7528 W: 1792 L: 1776 D: 3960
Penta | [10, 828, 2070, 848, 8]
```
https://ob.int0x80.ca/test/935/

Bench: 2904242