### PR TITLE
Require that eval must beat beta in the first place for NMP

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -580,7 +580,7 @@ Value negamax(Position &pos, ThreadInfo &ti, int depth, Value alpha = -VALUE_INF
 	// Null-move pruning
 	int npieces = arch::popcnt(pos.piece_boards[OCC(WHITE)] | pos.piece_boards[OCC(BLACK)]);
 	int npawns_and_kings = arch::popcnt(pos.piece_boards[PAWN] | pos.piece_boards[KING]);
-	if (cutnode && !in_check && !ti.nmp_disable && npieces != npawns_and_kings && cur_eval >= beta + nmp_margin() - nmp_depth() * depth && depth >= 2 && !excluded) { // Avoid NMP in pawn endgames
+	if (cutnode && !in_check && !ti.nmp_disable && npieces != npawns_and_kings && cur_eval >= beta && cur_eval >= beta + nmp_margin() - nmp_depth() * depth && depth >= 2 && !excluded) { // Avoid NMP in pawn endgames
 		/**
 		 * This works off the *null-move observation*.
 		 *


### PR DESCRIPTION
```
Elo   | 1.46 +- 1.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.73 (-2.25, 2.89) [0.00, 5.00]
Games | N: 33936 W: 8061 L: 7918 D: 17957
Penta | [27, 3815, 9128, 3984, 14]
```
https://ob.int0x80.ca/test/955/

Bench: 2458548