### PR TITLE
Age history by 3/4

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -1062,8 +1062,8 @@ void iterativedeepening(Position &pos, ThreadInfo &ti, int depth) {
 		for (int j = 0; j < 64; j++) {
 			for (int k = 0; k < 2; k++) {
 				for (int l = 0; l < 2; l++) {
-					ti.thread_hist.history[0][i][j][k][l] /= 2;
-					ti.thread_hist.history[1][i][j][k][l] /= 2;
+					ti.thread_hist.history[0][i][j][k][l] = ti.thread_hist.history[0][i][j][k][l] * 3 / 4;
+					ti.thread_hist.history[1][i][j][k][l] = ti.thread_hist.history[1][i][j][k][l] * 3 / 4;
 				}
 			}
 		}


### PR DESCRIPTION
```
Elo   | 3.24 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 5.00]
Games | N: 18972 W: 4648 L: 4471 D: 9853
Penta | [64, 2222, 4755, 2363, 82]
```
https://ob.int0x80.ca/test/962/

Bench: 2458548