### PR TITLE
Do not zero-allocate the memory in pzstd::vector

### DIFF
--- a/engine/pzstl/vector.hpp
+++ b/engine/pzstl/vector.hpp
@@ -24,8 +24,10 @@ namespace pzstd {
 	template <typename T, size_t MaxSize = PZSTD_DEFAULT_SIZE>
 	struct vector {
 		// It is necessary to write this class using static allocation only
-		T data[MaxSize];
-		uint16_t sz = 0;
+		union { T data[MaxSize]; };
+		uint16_t sz;
+
+		vector() : sz(0) {}
 
 		void push_back(T value) noexcept {
 			data[sz++] = value;

--- a/engine/pzstl/vector.hpp
+++ b/engine/pzstl/vector.hpp
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+
 #define PZSTD_DEFAULT_SIZE 256
 
 namespace pzstd {
@@ -29,16 +32,21 @@ namespace pzstd {
 
 		vector() : sz(0) {}
 
-		void push_back(T value) noexcept {
-			data[sz++] = value;
+		void push_back(const T &value) {
+			new (&data[sz++]) T(value);
 		}
-		void pop_back() noexcept {
-			sz--;
+		void push_back(T &&value) {
+			new (&data[sz++]) T(value);
+		}
+		void pop_back() {
+			~T(&data[--sz]);
 		}
 		void clear() {
-			sz = 0;
+			while (sz > 0) {
+				~T(&data[--sz]);
+			}
 		}
-		uint16_t count(T value) const {
+		uint16_t count(const T &value) const {
 			uint16_t cnt = 0;
 			for (uint16_t i = 0; i < sz; i++) {
 				if (data[i] == value) {


### PR DESCRIPTION
Should be a slight speedup, somewhere around ~5%

```
Elo   | 8.13 +- 5.06 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 5126 W: 1342 L: 1222 D: 2562
Penta | [26, 559, 1276, 673, 29]
```
https://ob.int0x80.ca/test/979/

Bench: 2186605