### PR TITLE
Add dual activation

### DIFF
--- a/engine/nnue/network.cpp
+++ b/engine/nnue/network.cpp
@@ -41,7 +41,7 @@ void Network::load() {
 
 	for (int i = 0; i < NBUCKETS; i++) {
 		for (int j = 0; j < L3_SIZE; j++) {
-			for (int k = 0; k < L2_SIZE; k++) {
+			for (int k = 0; k < L2_SIZE * 2; k++) {
 				memcpy(&l2_weights[i][k][j], ptr, 4);
 				ptr += 4;
 			}
@@ -55,6 +55,9 @@ void Network::load() {
 	ptr += sizeof(output_weights);
 
 	memcpy(&output_biases, ptr, sizeof(output_biases));
+	ptr += sizeof(output_biases);
+
+	std::cout << ptr - (char *)gnetwork_weightsData << " bytes loaded for NNUE network" << std::endl;
 }
 
 int calculate_index(Square sq, PieceType pt, bool side, bool perspective, int nbucket) {
@@ -126,15 +129,12 @@ int32_t nnue_eval(const Network &net, const Accumulator &stm, const Accumulator 
 		// val is activated with CReLU and val2 with SCReLU
 		ivec i_val = simd::load_ivec((ivec *)&l2i[i]);
 		fvec val = simd::cvt_i32_f32(i_val);
-		fvec val2 = simd::cvt_i32_f32(i_val);
 
 		fvec bias = simd::load_fvec(&net.l1_biases[nbucket][i]);
-		fvec bias2 = simd::load_fvec(&net.l1_biases[nbucket][i + L2_SIZE]);
 
 		val = simd::fma_f32(val, div, bias);
-		val2 = simd::fma_f32(val2, div, bias2);
 
-		val2 = simd::mul_f32(val2, val2); // note that order is changed for dual activation (CSReLU)
+		fvec val2 = simd::mul_f32(val, val); // note that order is changed for dual activation (CSReLU)
 
 		val = simd::clamp_f32(val, f_zero, f_clip);
 		val2 = simd::clamp_f32(val2, f_zero, f_clip);

--- a/engine/nnue/network.cpp
+++ b/engine/nnue/network.cpp
@@ -56,8 +56,6 @@ void Network::load() {
 
 	memcpy(&output_biases, ptr, sizeof(output_biases));
 	ptr += sizeof(output_biases);
-
-	std::cout << ptr - (char *)gnetwork_weightsData << " bytes loaded for NNUE network" << std::endl;
 }
 
 int calculate_index(Square sq, PieceType pt, bool side, bool perspective, int nbucket) {
@@ -126,7 +124,7 @@ int32_t nnue_eval(const Network &net, const Accumulator &stm, const Accumulator 
 	// Convert l2 into a proper float array
 	for (int i = 0; i < L2_SIZE; i += FLOATS_PER_VEC) {
 		// using the raw values, do dual activation
-		// val is activated with CReLU and val2 with SCReLU
+		// val is activated with CReLU and val2 with CSReLU
 		ivec i_val = simd::load_ivec((ivec *)&l2i[i]);
 		fvec val = simd::cvt_i32_f32(i_val);
 

--- a/engine/nnue/network.cpp
+++ b/engine/nnue/network.cpp
@@ -79,7 +79,7 @@ int32_t nnue_eval(const Network &net, const Accumulator &stm, const Accumulator 
 
 	alignas(64) uint8_t l1[L1_SIZE];
 	alignas(64) int32_t l2i[L2_SIZE];
-	alignas(64) float l2[L2_SIZE];
+	alignas(64) float l2[L2_SIZE * 2];
 	alignas(64) float l3[L3_SIZE];
 
 	// Pairwise mul
@@ -122,18 +122,25 @@ int32_t nnue_eval(const Network &net, const Accumulator &stm, const Accumulator 
 
 	// Convert l2 into a proper float array
 	for (int i = 0; i < L2_SIZE; i += FLOATS_PER_VEC) {
+		// using the raw values, do dual activation
+		// val is activated with CReLU and val2 with SCReLU
 		ivec i_val = simd::load_ivec((ivec *)&l2i[i]);
 		fvec val = simd::cvt_i32_f32(i_val);
+		fvec val2 = simd::cvt_i32_f32(i_val);
 
 		fvec bias = simd::load_fvec(&net.l1_biases[nbucket][i]);
+		fvec bias2 = simd::load_fvec(&net.l1_biases[nbucket][i + L2_SIZE]);
 
 		val = simd::fma_f32(val, div, bias);
+		val2 = simd::fma_f32(val2, div, bias2);
+
+		val2 = simd::mul_f32(val2, val2); // note that order is changed for dual activation (CSReLU)
 
 		val = simd::clamp_f32(val, f_zero, f_clip);
-
-		val = simd::mul_f32(val, val);
+		val2 = simd::clamp_f32(val2, f_zero, f_clip);
 
 		simd::store_f32(&l2[i], val);
+		simd::store_f32(&l2[i + L2_SIZE], val2);
 	}
 
 	for (int i = 0; i < L3_SIZE; i += FLOATS_PER_VEC * L2_UNROLL) {
@@ -141,7 +148,7 @@ int32_t nnue_eval(const Network &net, const Accumulator &stm, const Accumulator 
 		for (int j = 0; j < L2_UNROLL; j++)
 			sums[j] = simd::load_fvec(&net.l2_biases[nbucket][i + j * FLOATS_PER_VEC]);
 
-		for (int j = 0; j < L2_SIZE; j++) {
+		for (int j = 0; j < L2_SIZE * 2; j++) {
 			fvec val = simd::broadcast_f32(l2[j]);
 
 			for (int k = 0; k < L2_UNROLL; k++) {

--- a/engine/nnue/network.hpp
+++ b/engine/nnue/network.hpp
@@ -50,7 +50,7 @@ struct alignas(32) Network {
 	int16_t accumulator_biases[L1_SIZE];
 
 	int8_t l1_weights[NBUCKETS][L2_SIZE][L1_SIZE];
-	float l1_biases[NBUCKETS][L2_SIZE];
+	float l1_biases[NBUCKETS][L2_SIZE * 2];
 
 	float l2_weights[NBUCKETS][L2_SIZE * 2][L3_SIZE];
 	float l2_biases[NBUCKETS][L3_SIZE];

--- a/engine/nnue/network.hpp
+++ b/engine/nnue/network.hpp
@@ -50,7 +50,7 @@ struct alignas(32) Network {
 	int16_t accumulator_biases[L1_SIZE];
 
 	int8_t l1_weights[NBUCKETS][L2_SIZE][L1_SIZE];
-	float l1_biases[NBUCKETS][L2_SIZE * 2];
+	float l1_biases[NBUCKETS][L2_SIZE];
 
 	float l2_weights[NBUCKETS][L2_SIZE * 2][L3_SIZE];
 	float l2_biases[NBUCKETS][L3_SIZE];

--- a/engine/nnue/network.hpp
+++ b/engine/nnue/network.hpp
@@ -52,7 +52,7 @@ struct alignas(32) Network {
 	int8_t l1_weights[NBUCKETS][L2_SIZE][L1_SIZE];
 	float l1_biases[NBUCKETS][L2_SIZE];
 
-	float l2_weights[NBUCKETS][L2_SIZE][L3_SIZE];
+	float l2_weights[NBUCKETS][L2_SIZE * 2][L3_SIZE];
 	float l2_biases[NBUCKETS][L3_SIZE];
 
 	float output_weights[NBUCKETS][L3_SIZE];


### PR DESCRIPTION
Dual activation involves changing the L1->L2 activation from a single SCReLU to both CReLU and CSReLU. By combining two different activation functions, we are able to encode more information. Because we don't change the L1->L2 weights, the computational cost is minimal for a reasonable gain in evaluation accuracy.

The effective size of L2 therefore changes from 16 neurons to 32 neurons, where the first 16 are activated by CReLU and the latter 16 are activated by CSReLU. Thus, the L2->L3 transformation becomes a 32x32 matrix multiplication and the number of weights in that layer doubles.