### PR TITLE
Fix handling for checkmate on the fifty move rule

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -457,8 +457,25 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 		return alpha;
 	}
 
+	bool in_check = pos.checkers[pos.side];
+
 	// Threefold or 50 move rule
 	if (!root && (rp.threefold(ply, pos.zobrist_without_ep()) || pos.halfmove >= 100 || pos.insufficient_material())) {
+		if (pos.halfmove >= 100 && in_check) {
+			// special case: if we are in checkmate on the 50-move rule, it's actually a loss
+			// must do an extra check for mate
+			pzstd::vector<Move> moves;
+			pos.legal_moves(moves);
+			bool mate = true;
+			for (Move &move : moves) {
+				if (pos.is_legal(move)) {
+					mate = false;
+					break;
+				}
+			}
+			if (mate) return -VALUE_MATE + ply;
+		}
+
 		return 0;
 	}
 
@@ -529,8 +546,6 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 			}
 		}
 	}
-
-	bool in_check = pos.checkers[pos.side];
 
 	// Evaluate and correct evaluation
 	Value cur_eval = 0;


### PR DESCRIPTION
```
Elo   | 4.35 +- 2.98 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 13342 W: 3366 L: 3199 D: 6777
Penta | [18, 1535, 3411, 1676, 31]
```
https://ob.int0x80.ca/test/1006/

Bench: 2079283