### PR TITLE
Do history LMR for noisies too

### DIFF
--- a/engine/params.hpp
+++ b/engine/params.hpp
@@ -94,6 +94,7 @@ TUNE(lmr_cutoffcnt, 709, 0, 2048, 128);
 TUNE(lmr_ttpv, 830, 0, 2048, 128);
 TUNE(lmr_killer, 1149, 0, 2048, 128);
 TUNE(lmr_hist, 11, 1, 40, 4);
+TUNE(lmr_capt_hist, 8, 1, 30, 3);
 TUNE(lmr_ttcapt, 865, 0, 2048, 128);
 TUNE(lmr_ttpv_alpha, 362, -1024, 1024, 256);
 TUNE(lmr_corr, 219, 0, 1024, 128);

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -932,6 +932,8 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 
 			if (!capt && !promo)
 				r -= hist * lmr_hist() / 128;
+			else if (capt)
+				r -= hist * lmr_capt_hist() / 128;
 
 			int searched_depth = std::clamp(newdepth - r / 1024, 1, newdepth + 1);
 


### PR DESCRIPTION
Passed STC
```
Elo   | 5.22 +- 3.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11116 W: 2805 L: 2638 D: 5673
Penta | [51, 1247, 2794, 1416, 50]
```
https://ob.int0x80.ca/test/1002/

Unfinished LTC (but scaler penta!!111!)
```
Elo   | 1.41 +- 2.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.47 (-2.25, 2.89) [0.00, 4.00]
Games | N: 16540 W: 4006 L: 3939 D: 8595
Penta | [20, 1904, 4348, 1985, 13]
```
https://ob.int0x80.ca/test/1003/

Bench: 2073984