### PR TITLE
Lower margin for cutoffcnt LMR

### DIFF
--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -910,7 +910,7 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 			r -= lmr_base();
 
 			r -= lmr_pv() * pv; // Reduce less in PV nodes
-			r += lmr_cutoffcnt() * ((ss + 1)->cutoffcnt > 3);
+			r += lmr_cutoffcnt() * ((ss + 1)->cutoffcnt > 2);
 			r -= lmr_ttpv() * ttpv;
 
 			if (move == ss->killer) {


### PR DESCRIPTION
whatever just let the spsa deal with it

```
Elo   | 2.33 +- 3.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.88 (-2.25, 2.89) [0.00, 4.00]
Games | N: 11026 W: 2766 L: 2692 D: 5568
Penta | [45, 1307, 2749, 1353, 59]
```
https://ob.int0x80.ca/test/1015/

Bench: 2163340