### PR TITLE
Add 50-move rule scaling to eval

### DIFF
--- a/engine/eval.cpp
+++ b/engine/eval.cpp
@@ -52,7 +52,7 @@ Value eval(Position &pos, AccumulatorManager &am) {
 						  BishopValue * arch::popcnt(pos.piece_boards[BISHOP]) + RookValue * arch::popcnt(pos.piece_boards[ROOK]) +
 						  QueenValue * arch::popcnt(pos.piece_boards[QUEEN]);
 
-	return score * (26500 + mat_phase) / 32768;
+	return (int64_t)score * (26500 + mat_phase) * (200 - pos.halfmove) / 200 / 32768;
 }
 
 std::array<Value, 8> debug_eval(Position &pos) {


### PR DESCRIPTION
Unfinished LTC progression [2.14 LLR on [-4, 0] nonreg; 3.15 LLR on [-5, 0])
```
Elo   | 0.41 +- 2.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -0.88 (-2.25, 2.89) [0.00, 4.00]
Games | N: 22778 W: 5385 L: 5358 D: 12035
Penta | [21, 2664, 5995, 2685, 24]
```
https://ob.int0x80.ca/test/1017/

Passed STC endgames
```
Elo   | 9.44 +- 4.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 4968 W: 1394 L: 1259 D: 2315
Penta | [1, 501, 1348, 630, 4]
```
https://ob.int0x80.ca/test/1018/

Passed LTC endgames
```
Elo   | 6.54 +- 3.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 4.00]
Games | N: 7444 W: 1976 L: 1836 D: 3632
Penta | [0, 772, 2038, 912, 0]
```
https://ob.int0x80.ca/test/1019/

Bench: 2120234