### PR TITLE
Use TB score to adjust search score

### DIFF
--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -38,9 +38,9 @@ size_t TT_SIZE = DEFAULT_TT_SIZE;
 bool quiet = false, dfrc_uci = false;
 int move_overhead = 0;
 
-uint64_t timemgmt(int64_t remtime, int64_t inc = 0) {
+int64_t timemgmt(int64_t remtime, int64_t inc = 0) {
 	// Return time in ms that we can spend on this move
-	uint64_t x = std::max(1ll, (long long)(remtime * (tm_rem() / 100.0) + inc * (tm_inc() / 100.0)));
+	int64_t x = std::max(1ll, (long long)(remtime * (tm_rem() / 100.0) + inc * (tm_inc() / 100.0)));
 	x = std::min(x, remtime - move_overhead); // prevent situations with large inc but low time where we lose on time
 	return x;
 }

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -41,7 +41,7 @@ int move_overhead = 0;
 uint64_t timemgmt(int64_t remtime, int64_t inc = 0) {
 	// Return time in ms that we can spend on this move
 	uint64_t x = std::max(1ll, (long long)(remtime * (tm_rem() / 100.0) + inc * (tm_inc() / 100.0)));
-	x = std::min(x, (uint64_t)remtime - move_overhead); // prevent situations with large inc but low time where we lose on time
+	x = std::min(x, remtime - move_overhead); // prevent situations with large inc but low time where we lose on time
 	return x;
 }
 

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -522,6 +522,7 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 	 *
 	 * If tablebases are available, we can look up our position to get a perfect evaluation.
 	 */
+	Value syzygy_min = -VALUE_INFINITE, syzygy_max = VALUE_INFINITE;
 	if (!root && !excluded && tbman.initialized && depth >= tbman.min_depth) {
 		auto tb_res = tbman.probe_pos(pos);
 		if (tb_res.has_value()) {
@@ -541,8 +542,17 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 				tb_bound = UPPER_BOUND;
 
 			if (tb_bound == EXACT || (tb_bound == LOWER_BOUND && tb_score >= beta) || (tb_bound == UPPER_BOUND && tb_score <= alpha)) {
-				ttable.store(pos.zobrist, score_to_tt(tb_score, ply), VALUE_NONE, depth, tb_bound, ttpv, NullMove);
+				ttable.store(pos.zobrist, score_to_tt(tb_score, ply), VALUE_NONE, std::min(MAX_PLY, depth + 5), tb_bound, ttpv, NullMove);
 				return tb_score;
+			}
+
+			if (pv && tb_bound == LOWER_BOUND) {
+				alpha = std::max(alpha, tb_score);
+				syzygy_min = tb_score;
+			}
+
+			if (pv && tb_bound == UPPER_BOUND) {
+				syzygy_max = tb_score;
 			}
 		}
 	}
@@ -1014,6 +1024,7 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 				// note that best and score are functionally equivalent here; best is just what's returned + stored to TT
 				best = (score * depth + beta) / (depth + 1); // wtf?????
 			}
+			best = std::clamp(best, syzygy_min, syzygy_max);
 			if (ss->killer != move) {
 				ss->killer = move; // Update killer move
 			}
@@ -1048,6 +1059,8 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 		else
 			return 0;
 	}
+
+	best = std::clamp(best, syzygy_min, syzygy_max);
 
 	bool best_iscapture = pos.is_capture(best_move);
 	bool best_ispromo = (best_move.type() == PROMOTION);

--- a/engine/search.cpp
+++ b/engine/search.cpp
@@ -542,7 +542,7 @@ Value negamax(Position &pos, ThreadInfo &ti, SSEntry *ss, int depth, Value alpha
 				tb_bound = UPPER_BOUND;
 
 			if (tb_bound == EXACT || (tb_bound == LOWER_BOUND && tb_score >= beta) || (tb_bound == UPPER_BOUND && tb_score <= alpha)) {
-				ttable.store(pos.zobrist, score_to_tt(tb_score, ply), VALUE_NONE, std::min(MAX_PLY, depth + 5), tb_bound, ttpv, NullMove);
+				ttable.store(pos.zobrist, score_to_tt(tb_score, ply), VALUE_NONE, depth, tb_bound, ttpv, NullMove);
 				return tb_score;
 			}
 


### PR DESCRIPTION
```
Elo   | 0.26 +- 1.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.14 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 25088 W: 6670 L: 6651 D: 11767
Penta | [6, 2647, 7221, 2662, 8]
```
https://ob.int0x80.ca/test/1029/

Bench: 2120234